### PR TITLE
Fixed order of arguments on assertEquals

### DIFF
--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -53,23 +53,23 @@ class BoxTestCase(unittest.TestCase):
         sub_box_1 = selection.SubBox((0, 0, 0), (5, 5, 5))
         box_1 = selection.SelectionBox((sub_box_1,))
 
-        self.assertEqual(len(box_1), 1)
+        self.assertEqual(1, len(box_1))
         box_1.add_box(selection.SubBox((0, 5, 0), (5, 10, 5)))
-        self.assertEqual(len(box_1), 1)
+        self.assertEqual(1, len(box_1))
         box_1.add_box(selection.SubBox((0, 10, 0), (5, 15, 5)))
-        self.assertEqual(len(box_1), 1)
+        self.assertEqual(1, len(box_1))
 
         box_2 = selection.SelectionBox((sub_box_1,))
-        self.assertEqual(len(box_2), 1)
+        self.assertEqual(1, len(box_2))
         box_2.add_box(selection.SubBox((0, 6, 0), (5, 10, 5)))
-        self.assertEqual(len(box_2), 2)
+        self.assertEqual(2, len(box_2))
 
         box_3 = selection.SelectionBox((sub_box_1,))
-        self.assertEqual(len(box_3), 1)
+        self.assertEqual(1, len(box_3))
         box_3.add_box(selection.SubBox((0, 10, 0), (5, 15, 5)))
-        self.assertEqual(len(box_3), 2)
+        self.assertEqual(2, len(box_3))
         box_3.add_box(selection.SubBox((0, 5, 0), (5, 10, 5)))
-        self.assertEqual(len(box_3), 1)
+        self.assertEqual(1, len(box_3))
 
     def test_single_block_box(self):
         sub_box_1 = selection.SubBox((0, 0, 0), (0, 0, 1))
@@ -78,10 +78,10 @@ class BoxTestCase(unittest.TestCase):
         self.assertEqual((0, 0, 1), sub_box_1.shape)
         self.assertEqual(2, len([x for x in sub_box_1]))
 
-        self.assertTrue((0, 0, 0) in sub_box_1)
-        self.assertTrue((0, 0, 1) in sub_box_1)
+        self.assertIn((0, 0, 0), sub_box_1)
+        self.assertIn((0, 0, 1), sub_box_1)
 
-        self.assertFalse((0, 0, 2) in sub_box_1)
+        self.assertNotIn((0, 0, 2), sub_box_1)
 
     def test_sorted_iterator(self):
         sub_box_1 = selection.SubBox((0, 0, 0), (4, 4, 4))

--- a/tests/test_format_proto_1.py
+++ b/tests/test_format_proto_1.py
@@ -16,7 +16,7 @@ class TestPrototype112(unittest.TestCase):
         self.proto = definition_manager.DefinitionManager("1_12")
 
     def test_direct_access(self):
-        self.assertEqual(self.proto.blocks["minecraft:stone"], [1, 0])
+        self.assertEqual( [1, 0], self.proto.blocks["minecraft:stone"])
 
     def test_get_internal_block(self):
         stone_def = self.proto.get_internal_block(basename="stone")
@@ -26,14 +26,14 @@ class TestPrototype112(unittest.TestCase):
         )
 
         self.assertIsInstance(stone_def, dict)
-        self.assertEqual(stone_def["name"], "Stone")
+        self.assertEqual("Stone", stone_def["name"])
 
         self.assertIsInstance(granite_def, dict)
-        self.assertEqual(granite_def["name"], "Granite")
+        self.assertEqual("Granite", granite_def["name"])
         self.assertNotEqual(granite_def, stone_def)
 
         self.assertIsInstance(oak_log_axis_x, dict)
-        self.assertEqual(oak_log_axis_x["name"], "Oak Log (East/West)")
+        self.assertEqual("Oak Log (East/West)", oak_log_axis_x["name"])
         self.assertNotEqual(
             oak_log_axis_x,
             self.proto.get_internal_block(basename="oak_log", properties={"axis": "y"}),
@@ -52,7 +52,7 @@ class TestPrototype113(unittest.TestCase):
         self.proto = definition_manager.DefinitionManager("1_13")
 
     def test_direct_access(self):
-        self.assertEqual(self.proto.blocks["minecraft:stone"], "minecraft:stone")
+        self.assertEqual("minecraft:stone", self.proto.blocks["minecraft:stone"])
 
     def test_get_internal_block(self):
         stone_def = self.proto.get_internal_block(basename="stone")
@@ -62,14 +62,14 @@ class TestPrototype113(unittest.TestCase):
         )
 
         self.assertIsInstance(stone_def, dict)
-        self.assertEqual(stone_def["name"], "Stone")
+        self.assertEqual("Stone", stone_def["name"])
 
         self.assertIsInstance(granite_def, dict)
-        self.assertEqual(granite_def["name"], "Granite")
-        self.assertNotEqual(granite_def, stone_def)
+        self.assertEqual("Granite", granite_def["name"])
+        self.assertNotEqual(stone_def, granite_def)
 
         self.assertIsInstance(oak_log_axis_x, dict)
-        self.assertEqual(oak_log_axis_x["name"], "Oak Log (East/West)")
+        self.assertEqual("Oak Log (East/West)", oak_log_axis_x["name"])
         self.assertNotEqual(
             oak_log_axis_x,
             self.proto.get_internal_block(basename="oak_log", properties={"axis": "y"}),

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -12,12 +12,12 @@ class DefinitionBasedLoaderTestCase(unittest.TestCase):
 
     def test_identifing(self):
         name, _format = self.loader.identify(get_world_path("1.12.2 World"))
-        self.assertEqual(name, "1_12")
-        self.assertEqual(_format, "anvil")
+        self.assertEqual("1_12", name)
+        self.assertEqual("anvil", _format)
 
         name, _format = self.loader.identify(get_world_path("1.13 World"))
-        self.assertEqual(name, "1_13")
-        self.assertEqual(_format, "anvil2")
+        self.assertEqual("1_13", name)
+        self.assertEqual("anvil2", _format)
 
     def test_loading(self):
         world_obj = self.loader.load_world(get_world_path("1.12.2 World"))

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -61,9 +61,9 @@ class AnvilWorldTestCase(unittest.TestCase):
         target_box = SelectionBox((subbx2,))
 
         self.assertEqual(
-            self.world.get_block(1, 70, 3), "minecraft:stone"
+            "minecraft:stone", self.world.get_block(1, 70, 3)
         )  # Sanity check
-        self.assertEqual(self.world.get_block(1, 70, 5), "minecraft:granite")
+        self.assertEqual("minecraft:granite", self.world.get_block(1, 70, 5))
 
         self.world.run_operation_from_operation_name("clone", src_box, target_box)
 


### PR DESCRIPTION
This makes the order consistant across the code and brings it in line
with the error messages, which list the first parameter as expected and
second as actual.