### PR TITLE
Added black stylechecking to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-{{ checksum "requirements-dev.txt" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -25,18 +25,25 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: run tests
           command: |
             . venv/bin/activate
             python -m unittest discover -v -s tests
+
+      - run:
+          name: run stylecheck
+          command: |
+            . venv/bin/activate
+            python -m black --check src
+            python -m black --check tests
 
       - store_artifacts:
           path: test-reports

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 Sphinx==1.7.4
 sphinx-autodoc-typehints==1.3.0
 sphinx_rtd_theme==0.3.1
-black==18.4a2
+black==18.9b0
 PyInstaller==3.4
 pre_commit==1.11.1

--- a/src/formats/anvil/anvil_world.py
+++ b/src/formats/anvil/anvil_world.py
@@ -33,17 +33,17 @@ class _AnvilRegionManager:
             if not self.load_region(rx, rz):
                 raise Exception()
 
-        cx &= 0x1f
-        cz &= 0x1f
+        cx &= 0x1F
+        cz &= 0x1F
 
         chunk_offset = self._loaded_regions[key]["offsets"][
-            (cx & 0x1f) + (cz & 0x1f) * 32
+            (cx & 0x1F) + (cz & 0x1F) * 32
         ]
         if chunk_offset == 0:
             raise Exception()
 
         sector_start = chunk_offset >> 8
-        number_of_sectors = chunk_offset & 0xff
+        number_of_sectors = chunk_offset & 0xFF
 
         if number_of_sectors == 0:
             raise Exception()
@@ -93,8 +93,8 @@ class _AnvilRegionManager:
             self._loaded_regions[key] = {}
 
             file_size = path.getsize(filename)
-            if file_size & 0xfff:
-                file_size = (file_size | 0xfff) + 1
+            if file_size & 0xFFF:
+                file_size = (file_size | 0xFFF) + 1
                 fp.truncate(file_size)
 
             if not file_size:
@@ -122,7 +122,7 @@ class _AnvilRegionManager:
 
             for offset in offsets:
                 sector = offset >> 8
-                count = offset & 0xff
+                count = offset & 0xFF
 
                 for i in range(sector, sector + count):
                     if i >= len(free_sectors):

--- a/src/formats/anvil2/anvil2_world.py
+++ b/src/formats/anvil2/anvil2_world.py
@@ -32,17 +32,17 @@ class _Anvil2RegionManager:
         if not self.load_region(rx, rz):
             raise Exception()
 
-        cx &= 0x1f
-        cz &= 0x1f
+        cx &= 0x1F
+        cz &= 0x1F
 
         chunk_offset = self._loaded_regions[key]["offsets"][
-            (cx & 0x1f) + (cz & 0x1f) * 32
+            (cx & 0x1F) + (cz & 0x1F) * 32
         ]
         if chunk_offset == 0:
             raise Exception()
 
         sector_start = chunk_offset >> 8
-        number_of_sectors = chunk_offset & 0xff
+        number_of_sectors = chunk_offset & 0xFF
 
         if number_of_sectors == 0:
             raise Exception()
@@ -91,8 +91,8 @@ class _Anvil2RegionManager:
         self._loaded_regions[key] = {}
 
         file_size = path.getsize(filename)
-        if file_size & 0xfff:
-            file_size = (file_size | 0xfff) + 1
+        if file_size & 0xFFF:
+            file_size = (file_size | 0xFFF) + 1
             fp.truncate(file_size)
 
         if not file_size:
@@ -120,7 +120,7 @@ class _Anvil2RegionManager:
 
         for offset in offsets:
             sector = offset >> 8
-            count = offset & 0xff
+            count = offset & 0xFF
 
             for i in range(sector, sector + count):
                 if i >= len(free_sectors):

--- a/src/utils/world_utils.py
+++ b/src/utils/world_utils.py
@@ -88,7 +88,7 @@ def from_nibble_array(arr: ndarray) -> ndarray:
     new_arr = zeros((shape[0], shape[1], shape[2] * 2), dtype=uint8)
 
     new_arr[:, :, ::2] = arr
-    new_arr[:, :, ::2] &= 0xf
+    new_arr[:, :, ::2] &= 0xF
     new_arr[:, :, 1::2] = arr
     new_arr[:, :, 1::2] >>= 4
 

--- a/tests/test_format_proto_1.py
+++ b/tests/test_format_proto_1.py
@@ -15,7 +15,6 @@ class TestPrototypeBaseCases:
     # Wrapped in another class, so it isn't executed on it's own.
 
     class TestPrototype(unittest.TestCase):
-
         def _setUp(self, version):
             self.proto = definition_manager.DefinitionManager(version)
 
@@ -28,7 +27,6 @@ class TestPrototypeBaseCases:
 
             self.assertIsInstance(stone_def, dict)
             self.assertEqual("Stone", stone_def["name"])
-
 
             self.assertIsInstance(granite_def, dict)
             self.assertEqual("Granite", granite_def["name"])
@@ -54,7 +52,6 @@ class TestPrototypeBaseCases:
 
 
 class TestPrototype112(TestPrototypeBaseCases.TestPrototype):
-
     def setUp(self):
         self._setUp("java_1_12")
 
@@ -63,7 +60,6 @@ class TestPrototype112(TestPrototypeBaseCases.TestPrototype):
 
 
 class TestPrototype113(TestPrototypeBaseCases.TestPrototype):
-
     def setUp(self):
         self._setUp("java_1_13")
 

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -18,7 +18,6 @@ class WorldTestBaseCases:
     # Wrapped in another class, so it isn't executed on it's own.
 
     class WorldTestCase(unittest.TestCase):
-
         def _setUp(self, world_name):
             self.world = world_loader.loader.load_world(get_world_path(world_name))
 
@@ -108,13 +107,11 @@ class WorldTestBaseCases:
 
 
 class AnvilWorldTestCase(WorldTestBaseCases.WorldTestCase):
-
     def setUp(self):
         self._setUp("1.12.2 World")
 
 
 class Anvil2WorldTestCase(WorldTestBaseCases.WorldTestCase):
-
     def setUp(self):
         self._setUp("1.13 World")
 


### PR DESCRIPTION
This makes circleci fail if the code doesn't pass the black stylechecker.
Not sure if this is needed/wanted. Depends on how strictly you want the codestyle to be followed.

Also formats all files that weren't passing.