### PR TITLE
Improved world loading requirements

### DIFF
--- a/src/utils/format_utils.py
+++ b/src/utils/format_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from os.path import exists, join
+
+from nbt import nbt
+
+
+def check_all_exist(in_dir: str, *args: str) -> bool:
+    """
+    Check that all files exist in a parent directory
+
+    :param in_dir: The parent directory
+    :param *args: file or folder names to look for
+    :return: Boolean value indicating whether all were found
+    """
+
+    for child in args:
+        if not exists(join(in_dir, child)):
+            print(f"Didn't find {child}")
+            return False
+        else:
+            print(f"Found {child}")
+
+    return True
+
+
+def check_one_exists(in_dir: str, *args: str) -> bool:
+    """
+    Check that at least one file exists in a parent directory
+
+    :param in_dir: The parent directory
+    :param *args: file or folder names to look for
+    :return: Boolean value indicating whether at least one was found
+    """
+
+    for child in args:
+        if exists(join(in_dir, child)):
+            print(f"Found {child}")
+            return True
+
+    return False
+
+
+def load_leveldat(in_dir: str):
+    """
+    Load the root tag of the level.dat file in the directory
+
+    :param in_dir: The world directory containing the level.dat file
+    :return: The NBT root tag
+    """
+
+    fp = open(join(in_dir, "level.dat"), "rb")
+    root_tag = nbt.NBTFile(fileobj=fp)
+    fp.close()
+
+    return root_tag
+
+
+def check_version_leveldat(root_tag, min: int = None, max: int = None) -> bool:
+    """
+    Check the Version tag from the provided level.dat NBT structure
+
+    :param root_tag: the root level.dat tag
+    :param min: The lowest acceptable value (optional)
+    :param max: The highest acceptable value (optional)
+    :return: Whether the version tag falls in the correct range
+    """
+
+    version_found: int = root_tag.get("Data", nbt.TAG_Compound()).get(
+        "Version", nbt.TAG_Compound()
+    ).get("Id", nbt.TAG_Int(-1)).value
+
+    min_qualifies: bool = True
+    if min is not None:
+        min_qualifies = version_found >= min
+
+    max_qualifies: bool = True
+    if max is not None:
+        max_qualifies = version_found <= max
+
+    if __debug__:
+        min_text: str = f"{min} <= " if min is not None else ""
+        max_text: str = f" >= {max}" if max is not None else ""
+        print(f"Checking {min_text}{version_found}{max_text}")
+
+    return min_qualifies and max_qualifies

--- a/src/version_definitions/java_1_12/java_1_12.py
+++ b/src/version_definitions/java_1_12/java_1_12.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from os.path import exists, join
-
 from nbt import nbt
+
+from utils.format_utils import (
+    check_all_exist,
+    check_one_exists,
+    load_leveldat,
+    check_version_leveldat,
+)
 
 from api.world import World
 
@@ -12,24 +17,14 @@ FORMAT = "anvil"
 
 
 def identify(directory: str) -> bool:
-    if not (exists(join(directory, "region")) or exists(join(directory, "level.dat"))):
+    if not check_all_exist(directory, "region", "level.dat"):
         return False
 
-    if not exists(join(directory, "players")) and not exists(
-        join(directory, "playerdata")
-    ):
+    if not check_one_exists(directory, "playerdata", "players"):
         return False
 
-    fp = open(join(directory, "level.dat"), "rb")
-    root_tag = nbt.NBTFile(fileobj=fp)
-    fp.close()
-    if (
-        root_tag.get("Data", nbt.TAG_Compound())
-        .get("Version", nbt.TAG_Compound())
-        .get("Id", nbt.TAG_Int(-1))
-        .value
-        > 1451
-    ):
+    leveldat_root = load_leveldat(directory)
+    if not check_version_leveldat(leveldat_root, max=1343):
         return False
 
     return True


### PR DESCRIPTION
I've extracted the logic into common function calls.

The names are obviously up for suggestions but here they are as of writing this:

`check_all_exists` (checks for files/folders)
`check_one_exists` (checks for at least one of a set of files/folders)
`load_leveldat` (Loads the `level.dat` file)
`check_version_leveldat` (Compares the map version to a closed or open range of integers)

My intent with this was to recognize that the format files may grow in quantity going forward and concise requirement specification is critical.