### PR TITLE
Merge proto-blocks branch into impl-block-api branch

### DIFF
--- a/docs_source/api/blocks.rst
+++ b/docs_source/api/blocks.rst
@@ -1,0 +1,6 @@
+blocks module
+=============
+
+.. automodule:: api.blocks
+    :members:
+    :show-inheritance:

--- a/docs_source/api/blocks.rst
+++ b/docs_source/api/blocks.rst
@@ -3,4 +3,5 @@ blocks module
 
 .. automodule:: api.blocks
     :members:
+    :special-members:
     :show-inheritance:

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -233,6 +233,9 @@ class Block:
         :param other: The Block object to add to the end of this Block object's `extra_blocks`
         :return: A new Block object with the same data but with an additional Block at the end of ``extra_blocks``
         """
+        if not isinstance(other, Block):
+            return NotImplemented
+
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -263,6 +266,9 @@ class Block:
         :param other: The Block object to subtract from this Block objects' ``extra_blocks``
         :return: A new Block object without any instances of the subtracted block in ``extra_blocks``
         """
+        if not isinstance(other, Block):
+            return NotImplemented
+
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -287,14 +293,6 @@ class Block:
                 new_extras.append(eb)
 
         return Block(self._namespace, self._base_name, self._properties, new_extras)
-
-    def __iadd__(self, other: Block) -> TypeError:
-        raise TypeError("You cannot add an extra block to an already existing block")
-
-    def __isub__(self, other: Block) -> TypeError:
-        raise TypeError(
-            "You cannot subtract an extra block to an already existing block"
-        )
 
 
 class BlockManager:

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -76,6 +76,14 @@ class Block:
 
     @staticmethod
     def parse_blockstate_string(blockstate: str) -> Tuple[str, str, Dict[str, str]]:
+        """
+        Parses the supplied blockstate string and returns a tuple containing the namespace, base_name, and property
+        dictionary of the blockstate
+
+        :param blockstate: The blockstate string to parse
+        :return: The namespace, base_name, and property dictionary of the blockstate
+        """
+
         match = Block.blockstate_regex.match(blockstate)
         namespace = match.group("namespace") or "minecraft"
         base_name = match.group("base_name")

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -11,6 +11,10 @@ class MalformedBlockstateException(Exception):
 
 
 class Block:
+    """
+    Class to handle data about various blockstates and allow for extra blocks to be created and interacted with
+    """
+
     blockstate_regex = re.compile(
         r"(?:(?P<namespace>[a-z0-9_.-]+):)?(?P<base_name>[a-z0-9/._-]+)(?:\[(?P<property_name>[a-z0-9_]+)=(?P<property_value>[a-z0-9_]+)(?P<properties>.*)\])?"
     )
@@ -36,22 +40,47 @@ class Block:
 
     @property
     def namespace(self) -> str:
+        """
+        The namespace of the blockstate represented by the Block object (IE: `minecraft`)
+
+        :return: The namespace of the blockstate
+        """
         return self._namespace
 
     @property
     def base_name(self) -> str:
+        """
+        The base name of the blockstate represented by the Block object (IE: `stone`, `dirt`)
+
+        :return: The base name of the blockstate
+        """
         return self._base_name
 
     @property
     def properties(self) -> Dict[str, Union[str, bool, int]]:
+        """
+        The mapping of properties of the blockstate represented by the Block object (IE: `{"level": "1"}`)
+
+        :return: A dictionary of the properties of the blockstate
+        """
         return self._properties
 
     @property
     def blockstate(self) -> str:
+        """
+        The full blockstate string of the blockstate represented by the Block object (IE: `minecraft:stone`, `minecraft:oak_log[axis=x]`)
+
+        :return: The blockstate string
+        """
         return self._blockstate
 
     @property
     def extra_blocks(self) -> Union[Tuple, Tuple[Block]]:
+        """
+        Returns a tuple of the extra blocks contained in the Block instance
+
+        :return: A tuple of Block objects
+        """
         return self._extra_blocks
 
     def _gen_blockstate(self) -> str:
@@ -61,8 +90,28 @@ class Block:
             blockstate += f"[{','.join(props)}]"
         return blockstate
 
+    def remove_layer(self, layer: int) -> Block:
+        """
+        Removes the Block object from the specified layer and returns the resulting new Block object
+
+        :param layer: The layer of extra block to remove
+        :return: A new instance of Block with the same data but with the extra block at specified layer removed
+        """
+        return Block(
+            self._namespace,
+            self._base_name,
+            self._properties,
+            [*self._extra_blocks[:layer], *self._extra_blocks[layer + 1 :]],
+        )
+
     @classmethod
     def get_from_blockstate(cls, blockstate: str) -> Block:
+        """
+        Parses a blockstate string and returns a Block object that contains the data for that blockstate
+
+        :param blockstate: The blockstate string
+        :return: A Block object containing the data supplied in the blockstate
+        """
         match = Block.blockstate_regex.match(blockstate)
         namespace = match.group("namespace") or "minecraft"
         base_name = match.group("base_name")

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Union
 
+import numpy
+import time
+
 
 class MalformedBlockstateException(Exception):
     pass
@@ -17,18 +20,18 @@ class Block:
 
     def __init__(
         self,
-        resource_location: str,
+        namespace: str,
         base_name: str,
         properties: Dict[str, Union[str, bool, int]],
     ):
-        self._resource_location = resource_location
+        self._namespace = namespace
         self._base_name = base_name
         self._properties = properties
         self._blockstate = self._gen_blockstate()
 
     @property
-    def resource_location(self) -> str:
-        return self._resource_location
+    def namespace(self) -> str:
+        return self._namespace
 
     @property
     def base_name(self) -> str:
@@ -43,7 +46,7 @@ class Block:
         return self._blockstate
 
     def _gen_blockstate(self) -> str:
-        blockstate = f"{self._resource_location}:{self._base_name}"
+        blockstate = f"{self._namespace}:{self._base_name}"
         if self._properties:
             props = [f"{key}={value}" for key, value in self._properties.items()]
             blockstate += f"[{','.join(props)}]"
@@ -54,8 +57,12 @@ class Block:
         match = Block.blockstate_regex.match(blockstate)
         namespace = match.group("namespace") or "minecraft"
         base_name = match.group("base_name")
+
         if match.group("property_name") is not None:
             properties = {match.group("property_name"): match.group("property_value")}
+        else:
+            properties = {}
+
         properties_string = match.group("properties")
         if properties_string is not None:
             properties_match = Block.parameters_regex.finditer(properties_string)
@@ -81,32 +88,44 @@ class Block:
 
 class BlockManager:
     def __init__(self):
-        self._name_to_block_map: Dict[str, Block] = {}
+        self._index_to_block = numpy.array([], dtype=Block)
         self._block_to_index_map: Dict[Block, int] = {}
 
-    def __getitem__(self, item: Union[Block, str]) -> int:
+    def __getitem__(self, item: Union[Block, str, int]) -> int:
         if isinstance(item, str):
             item = self.get_block(item)
+
+        if isinstance(item, int):
+            return self._index_to_block[item]
+
         return self._block_to_index_map[item]
 
     def get_block(self, block: str) -> Block:
-        if block in self._name_to_block_map:
-            return self._name_to_block_map[block]
+        if block in self._block_to_index_map:
+            return self._index_to_block[self._block_to_index_map[block]]
 
-        self._name_to_block_map[block] = b = Block.get_from_blockstate(block)
+        b = Block.get_from_blockstate(block)
         self._block_to_index_map[b] = len(self._block_to_index_map)
+        self._index_to_block = numpy.append(self._index_to_block, [b])
+
         return b
 
 
 if __name__ == "__main__":
-    b = Block.get_from_blockstate("minecraft:air")
-    d = {b: 0}
-    print(b in d)
-    print("minecraft:air" in d)
+    b = Block.get_from_blockstate("minecraft:unknown")
 
     manager = BlockManager()
+    start1 = time.time()
     i1 = manager["minecraft:air"]
+    end1 = time.time()
     i2 = manager["minecraft:stone"]
+
+    start2 = time.time()
     i3 = manager["minecraft:air"]
+    end2 = time.time()
+    print(i1, i2, i3)
+    print(f"Creation: {end1 - start1}")
+    print(f"__getitem__: {end2 - start2}")
+
+    block = manager[4]
     i4 = manager[b]
-    print(i1, i2, i3, i4)

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Union
+
+
+class MalformedBlockstateException(Exception):
+    pass
+
+
+class Block:
+    def __init__(
+        self,
+        resource_location: str,
+        base_name: str,
+        properties: Dict[str, Union[str, bool, int]],
+    ):
+        self._resource_location = resource_location
+        self._base_name = base_name
+        self._properties = properties
+        self._blockstate = self._gen_blockstate()
+
+    @property
+    def resource_location(self) -> str:
+        return self._resource_location
+
+    @property
+    def base_name(self) -> str:
+        return self._base_name
+
+    @property
+    def properties(self) -> Dict[str, Union[str, bool, int]]:
+        return self._properties
+
+    @property
+    def blockstate(self) -> str:
+        return self._blockstate
+
+    def _gen_blockstate(self) -> str:
+        blockstate = f"{self._resource_location}:{self._base_name}"
+        if self._properties:
+            props = [f"{key}={value}" for key, value in self._properties.items()]
+            blockstate += f"[{','.join(props)}]"
+        return blockstate
+
+    @classmethod
+    def get_from_blockstate(cls, blockstate: str) -> Block:
+        if ":" in blockstate:
+            resource_location = blockstate[: blockstate.index(":")]
+        else:
+            resource_location = "unknown"
+
+        if "[" not in blockstate:
+            base_name = blockstate[blockstate.index(":") + 1 :]
+            properties = {}
+        else:
+            if "]" not in blockstate:
+                raise MalformedBlockstateException(
+                    f"Blockstate has missing end bracket: {blockstate}"
+                )
+
+            base_name = blockstate[blockstate.index(":") + 1 : blockstate.index("[")]
+            props = blockstate[blockstate.index("[") + 1 : blockstate.index("]")].split(
+                ","
+            )
+            properties = {}
+            for prop in props:
+                key, value = prop.split("=")
+                value = value.lower()
+
+                if value in ("true", "false"):
+                    properties[key] = bool(value)
+                elif value.isdigit():
+                    properties[key] = int(value)
+                else:
+                    properties[key] = value
+
+        return cls(resource_location, base_name, properties)
+
+    def __str__(self) -> str:
+        return self._blockstate
+
+    def __eq__(self, other: Union[Block, str]) -> bool:
+        if isinstance(other, Block):
+            other = other._blockstate
+        return self._blockstate == other
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __hash__(self):
+        return hash(self._blockstate)
+
+
+class BlockManager:
+    def __init__(self):
+        self._name_to_block_map: Dict[str, Block] = {}
+        self._block_to_index_map: Dict[Block, int] = {}
+
+    def __getitem__(self, item: Union[Block, str]) -> int:
+        if isinstance(item, str):
+            item = self.get_block(item)
+        return self._block_to_index_map[item]
+
+    def get_block(self, block: str) -> Block:
+        if block in self._name_to_block_map:
+            return self._name_to_block_map[block]
+
+        self._name_to_block_map[block] = b = Block.get_from_blockstate(block)
+        self._block_to_index_map[b] = len(self._block_to_index_map)
+        return b
+
+
+if __name__ == "__main__":
+    b = Block.get_from_blockstate("minecraft:air")
+    d = {b: 0}
+    print(b in d)
+    print("minecraft:air" in d)
+
+    manager = BlockManager()
+    i1 = manager["minecraft:air"]
+    i2 = manager["minecraft:stone"]
+    i3 = manager["minecraft:air"]
+    i4 = manager[b]
+    print(i1, i2, i3, i4)

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -34,6 +34,7 @@ class Block:
 
 
     Creating a new Block object by removing an extra block from all layers:
+
     *Note: This removes all instances of the Block object from extra blocks*
 
     >>> stone_granite = stone_water_granite - water_level_1 # Doesn't modify any of the other objects either

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -152,23 +152,29 @@ class Block:
             props = [f"{key}={value}" for key, value in self.properties.items()]
             self._blockstate = f"{self._blockstate}[{','.join(props)}]"
 
-    def _parse_blockstate_string(self):
-        match = Block.blockstate_regex.match(self._blockstate)
-        self._namespace = match.group("namespace") or "minecraft"
-        self._base_name = match.group("base_name")
+    @staticmethod
+    def parse_blockstate_string(blockstate: str) -> Tuple[str, str, Dict[str, str]]:
+        match = Block.blockstate_regex.match(blockstate)
+        namespace = match.group("namespace") or "minecraft"
+        base_name = match.group("base_name")
 
         if match.group("property_name") is not None:
-            self._properties = {
-                match.group("property_name"): match.group("property_value")
-            }
+            properties = {match.group("property_name"): match.group("property_value")}
         else:
-            self._properties = {}
+            properties = {}
 
         properties_string = match.group("properties")
         if properties_string is not None:
             properties_match = Block.parameters_regex.finditer(properties_string)
             for match in properties_match:
-                self._properties[match.group("name")] = match.group("value")
+                properties[match.group("name")] = match.group("value")
+
+        return namespace, base_name, properties
+
+    def _parse_blockstate_string(self):
+        self._namespace, self._base_name, self._properties = self.parse_blockstate_string(
+            self._blockstate
+        )
 
     def __str__(self) -> str:
         """

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -12,7 +12,46 @@ class MalformedBlockstateException(Exception):
 
 class Block:
     """
-    Class to handle data about various blockstates and allow for extra blocks to be created and interacted with
+    Class to handle data about various blockstates and allow for extra blocks to be created and interacted with. Here's
+    an example on how create a Block object with extra blocks:
+
+
+    Creating a new Block object with the base of ``stone`` and has an extra block of ``water[level=1]``:
+
+    >>> stone = Block.get_from_blockstate("minecraft:stone")
+    >>> water_level_1 = Block.get_from_blockstate("minecraft:water[level=1]")
+    >>> stone_with_extra_block = stone + water_level_1
+    >>> repr(stone_with_extra_block)
+    'Block(minecraft:stone, minecraft:water[level=1])'
+
+
+    Creating a new Block object with another layer of extra blocks:
+
+    >>> granite = Block.get_from_blockstate("minecraft:granite")
+    >>> stone_water_granite = stone_with_extra_block + granite # Doesn't modify any of the other objects
+    >>> repr(stone_water_granite)
+    'Block(minecraft:stone, minecraft:water[level=1], minecraft:granite)'
+
+
+    Creating a new Block object by removing an extra block from all layers:
+    *Note: This removes all instances of the Block object from extra blocks*
+
+    >>> stone_granite = stone_water_granite - water_level_1 # Doesn't modify any of the other objects either
+    >>> repr(stone_granite)
+    'Block(minecraft:stone, minecraft:granite)'
+
+
+    Creating a new Block object by removing a specific layer:
+
+    >>> oak_log_axis_x = Block.get_from_blockstate("minecraft:oak_log[axis=x]")
+    >>> stone_water_granite_water_oak_log = stone_water_granite + water_level_1 + oak_log_axis_x
+    >>> repr(stone_water_granite_water_oak_log)
+    'Block(minecraft:stone, minecraft:water[level=1], minecraft:granite, minecraft:water[level=1], minecraft:oak_log[axis=x])'
+
+    >>> stone_granite_water_oak_log = stone_water_granite_water_oak_log.remove_layer(0)
+    >>> repr(stone_granite_water_oak_log)
+    'Block(minecraft:stone, minecraft:granite, minecraft:water[level=1], minecraft:oak_log[axis=x])'
+
     """
 
     blockstate_regex = re.compile(

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -57,6 +57,14 @@ class Block:
 
     """
 
+    __slots__ = (
+        "_namespace",
+        "_base_name",
+        "_properties",
+        "_extra_blocks",
+        "_blockstate",
+    )  # Reduces memory footprint
+
     blockstate_regex = re.compile(
         r"(?:(?P<namespace>[a-z0-9_.-]+):)?(?P<base_name>[a-z0-9/._-]+)(?:\[(?P<property_name>[a-z0-9_]+)=(?P<property_value>[a-z0-9_]+)(?P<properties>.*)\])?"
     )

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -10,12 +10,10 @@ class MalformedBlockstateException(Exception):
 
 class Block:
     blockstate_regex = re.compile(
-        r"(?:(?P<namespace>[a-z0-9_.-]+):)?(?P<base_name>[a-z0-9/._-]+)(?:\[(?P<property_name>[a-z0-9/._-]+)=(?P<property_value>[a-z0-9/._-]+)(?P<properties>.*)\])?"
+        r"(?:(?P<namespace>[a-z0-9_.-]+):)?(?P<base_name>[a-z0-9/._-]+)(?:\[(?P<property_name>[a-z0-9_]+)=(?P<property_value>[a-z0-9_]+)(?P<properties>.*)\])?"
     )
 
-    parameters_regex = re.compile(
-        r"(?:,(?P<name>[a-z0-9/._-]+)=(?P<value>[a-z0-9/._-]+))"
-    )
+    parameters_regex = re.compile(r"(?:,(?P<name>[a-z0-9_]+)=(?P<value>[a-z0-9_]+))")
 
     def __init__(
         self,

--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -170,9 +170,15 @@ class Block:
         return cls(namespace, base_name, properties)
 
     def __str__(self) -> str:
+        """
+        :return: The base blockstate string of the Block object
+        """
         return self._blockstate
 
     def __repr__(self) -> str:
+        """
+        :return: The base blockstate string of the Block object along with the blockstate strings of included extra blocks
+        """
         return f"Block({', '.join([str(b) for b in (self, *self._extra_blocks)])})"
 
     def _compare_extra_blocks(self, other: Block) -> bool:
@@ -191,6 +197,12 @@ class Block:
         return True
 
     def __eq__(self, other: Block) -> bool:
+        """
+        Checks the equality of this Block object to another Block object
+
+        :param other: The Block object to check against
+        :return: True if the Blocks objects are equal, False otherwise
+        """
         if self.__class__ != other.__class__:
             return False
 
@@ -201,7 +213,12 @@ class Block:
             and self._compare_extra_blocks(other)
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        """
+        Hashes the Block object
+
+        :return: A hash of the Block object
+        """
         current_hash = hash(self._blockstate)
 
         if self._extra_blocks:
@@ -210,6 +227,12 @@ class Block:
         return current_hash
 
     def __add__(self, other: Block) -> Block:
+        """
+        Allows for other Block objects to be added to this Block object's ``extra_blocks``
+
+        :param other: The Block object to add to the end of this Block object's `extra_blocks`
+        :return: A new Block object with the same data but with an additional Block at the end of ``extra_blocks``
+        """
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -234,6 +257,12 @@ class Block:
         )
 
     def __sub__(self, other: Block) -> Block:
+        """
+        Allows for other Block objects to be subtracted from this Block object's ``extra_blocks``
+
+        :param other: The Block object to subtract from this Block objects' ``extra_blocks``
+        :return: A new Block object without any instances of the subtracted block in ``extra_blocks``
+        """
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -269,7 +298,14 @@ class Block:
 
 
 class BlockManager:
+    """
+    Class to handle the mappings between Block objects and their index-based internal IDs
+    """
+
     def __init__(self):
+        """
+        Creates a new BlockManager object
+        """
         self._index_to_block: List[Block] = []
         self._block_to_index_map: Dict[Block, int] = {}
 
@@ -278,8 +314,8 @@ class BlockManager:
         If a Block object or string is passed to this function, it'll return the internal ID/index of the
         blockstate. If an int is given, this method will return the Block object at that specified index.
 
-        :param item:
-        :return:
+        :param item: The Block object, blockstate string, or int to get the mapping data of
+        :return: An int if a Block object or blockstate string was supplied, a Block object if an int was supplied
         """
         if isinstance(item, str):
             item = self.get_block(item)
@@ -298,8 +334,15 @@ class BlockManager:
 
         return i
 
-    def get_block(self, block: str) -> Block:
-        b = Block.get_from_blockstate(block)
+    def get_block(self, blockstate: str) -> Block:
+        """
+        Creates a Block object from the supplied blockstate string, adds the object to the internal mappings, and then
+        returns the object.
+
+        :param blockstate: The blockstate string to add
+        :return: The Block object created with the supplied blockstate string
+        """
+        b = Block.get_from_blockstate(blockstate)
 
         if b in self._block_to_index_map:
             i = self._block_to_index_map[b]

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -81,8 +81,53 @@ class BlockTestCase(unittest.TestCase):
         self.assertEqual("stone", conglomerate_3.base_name)
         self.assertEqual({}, conglomerate_3.properties)
         self.assertEqual(2, len(conglomerate_3.extra_blocks))
-        print(repr(conglomerate_3))
         for block_1, block_2 in zip(conglomerate_3.extra_blocks, (water, granite)):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+    def test_remove_layer(self):
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
+        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        oak_log_axis_x = blocks.Block.get_from_blockstate("minecraft:oak_log[axis=x]")
+
+        conglomerate_1 = stone + water + dirt + dirt + granite
+        self.assertIsInstance(conglomerate_1, blocks.Block)
+        self.assertEqual("minecraft", conglomerate_1.namespace)
+        self.assertEqual("stone", conglomerate_1.base_name)
+        self.assertEqual({}, conglomerate_1.properties)
+        self.assertEqual(4, len(conglomerate_1.extra_blocks))
+        for block_1, block_2 in zip(
+            conglomerate_1.extra_blocks, (water, dirt, dirt, granite)
+        ):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+        new_conglomerate = conglomerate_1.remove_layer(1)
+        for block_1, block_2 in zip(
+            new_conglomerate.extra_blocks, (water, dirt, granite)
+        ):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+        conglomerate_2 = granite + water + stone + dirt + oak_log_axis_x
+        self.assertIsInstance(conglomerate_2, blocks.Block)
+        self.assertEqual("minecraft", conglomerate_2.namespace)
+        self.assertEqual("granite", conglomerate_2.base_name)
+        self.assertEqual({}, conglomerate_2.properties)
+        self.assertEqual(4, len(conglomerate_2.extra_blocks))
+        for block_1, block_2 in zip(
+            conglomerate_2.extra_blocks, (water, stone, dirt, oak_log_axis_x)
+        ):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+        new_conglomerate = conglomerate_2.remove_layer(2)
+        self.assertEqual(3, len(new_conglomerate.extra_blocks))
+        for block_1, block_2 in zip(
+            new_conglomerate.extra_blocks, (water, stone, oak_log_axis_x)
+        ):
             self.assertEqual(block_1, block_2)
             self.assertEqual(0, len(block_1.extra_blocks))
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -174,6 +174,81 @@ class BlockTestCase(unittest.TestCase):
         self.assertNotEqual(conglomerate_5, conglomerate_6)
         self.assertNotEqual(hash(conglomerate_5), hash(conglomerate_6))
 
+    def test_auto_waterlog(self):
+        brain_coral = blocks.Block.get_from_blockstate(
+            "minecraft:brain_coral[waterlogged=false]"
+        )
+        brain_coral_waterlogged = blocks.Block.get_from_blockstate(
+            "minecraft:brain_coral[waterlogged=true]"
+        )
+        water = blocks.Block.get_from_blockstate("minecraft:water")
+
+        self.assertNotEqual(brain_coral, brain_coral_waterlogged)
+        self.assertIsNot(brain_coral, brain_coral_waterlogged)
+
+        self.assertEqual("minecraft", brain_coral.namespace)
+        self.assertEqual("brain_coral", brain_coral.base_name)
+        self.assertEqual({}, brain_coral.properties)
+        self.assertEqual((), brain_coral.extra_blocks)
+
+        self.assertEqual("minecraft", brain_coral_waterlogged.namespace)
+        self.assertEqual("brain_coral", brain_coral_waterlogged.base_name)
+        self.assertEqual({}, brain_coral_waterlogged.properties)
+        self.assertEqual((water,), brain_coral_waterlogged.extra_blocks)
+
+        new_coral = brain_coral + water
+
+        self.assertEqual(brain_coral_waterlogged, new_coral)
+        self.assertIsNot(brain_coral_waterlogged, new_coral)
+
+
+class BlockManaerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.manager = blocks.BlockManager()
+
+        initial_dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        initial_stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        initial_granite = blocks.Block.get_from_blockstate("minecraft:granite")
+
+        initial_dirt_water = initial_dirt + blocks.Block.get_from_blockstate(
+            "minecraft:water"
+        )
+
+        # Partially populate the manager
+        self.manager[initial_dirt]
+        self.manager[initial_stone]
+        self.manager[initial_granite]
+        self.manager[initial_dirt_water]
+
+    def test_get_index_from_manager(self):
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+
+        self.assertEqual(0, self.manager[dirt])
+        self.assertEqual(1, self.manager[stone])
+        self.assertEqual(2, self.manager[granite])
+
+        water = blocks.Block.get_from_blockstate("minecraft:water")
+
+        dirt_water = dirt + water
+
+        self.assertNotEqual(dirt, dirt_water)
+        self.assertIsNot(dirt, dirt_water)
+        self.assertEqual(3, self.manager[dirt_water])
+
+    def test_get_block_from_manager(self):
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        water = blocks.Block.get_from_blockstate("minecraft:water")
+        dirt_water = dirt + water
+
+        self.assertEqual(dirt, self.manager[0])
+        self.assertEqual(stone, self.manager[1])
+        self.assertEqual(granite, self.manager[2])
+        self.assertEqual(dirt_water, self.manager[3])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -85,6 +85,23 @@ class BlockTestCase(unittest.TestCase):
             self.assertEqual(block_1, block_2)
             self.assertEqual(0, len(block_1.extra_blocks))
 
+        self.assertRaises(TypeError, lambda: stone + 1)
+        self.assertRaises(TypeError, lambda: stone - 1)
+
+    def test_extra_blocks_immutable(self):
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+
+        stone2 = stone
+        self.assertIs(stone, stone2)
+        stone2 += dirt
+        self.assertIsNot(stone, stone2)
+
+        stone3 = stone2
+        self.assertIs(stone2, stone3)
+        stone3 -= dirt
+        self.assertIsNot(stone, stone3)
+
     def test_remove_layer(self):
         stone = blocks.Block.get_from_blockstate("minecraft:stone")
         water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -175,7 +175,7 @@ class BlockTestCase(unittest.TestCase):
         self.assertNotEqual(hash(conglomerate_5), hash(conglomerate_6))
 
 
-class BlockManaerTestCase(unittest.TestCase):
+class BlockManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = blocks.BlockManager()
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -174,33 +174,6 @@ class BlockTestCase(unittest.TestCase):
         self.assertNotEqual(conglomerate_5, conglomerate_6)
         self.assertNotEqual(hash(conglomerate_5), hash(conglomerate_6))
 
-    def test_auto_waterlog(self):
-        brain_coral = blocks.Block.get_from_blockstate(
-            "minecraft:brain_coral[waterlogged=false]"
-        )
-        brain_coral_waterlogged = blocks.Block.get_from_blockstate(
-            "minecraft:brain_coral[waterlogged=true]"
-        )
-        water = blocks.Block.get_from_blockstate("minecraft:water")
-
-        self.assertNotEqual(brain_coral, brain_coral_waterlogged)
-        self.assertIsNot(brain_coral, brain_coral_waterlogged)
-
-        self.assertEqual("minecraft", brain_coral.namespace)
-        self.assertEqual("brain_coral", brain_coral.base_name)
-        self.assertEqual({}, brain_coral.properties)
-        self.assertEqual((), brain_coral.extra_blocks)
-
-        self.assertEqual("minecraft", brain_coral_waterlogged.namespace)
-        self.assertEqual("brain_coral", brain_coral_waterlogged.base_name)
-        self.assertEqual({}, brain_coral_waterlogged.properties)
-        self.assertEqual((water,), brain_coral_waterlogged.extra_blocks)
-
-        new_coral = brain_coral + water
-
-        self.assertEqual(brain_coral_waterlogged, new_coral)
-        self.assertIsNot(brain_coral_waterlogged, new_coral)
-
 
 class BlockManaerTestCase(unittest.TestCase):
     def setUp(self):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -7,23 +7,23 @@ except ModuleNotFoundError:
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
 
 import unittest
-from api import blocks
+from api.blocks import Block, BlockManager
 
 
 class BlockTestCase(unittest.TestCase):
     def test_get_from_blockstate(self):  # This is mostly just sanity checks
-        air = blocks.Block.get_from_blockstate("minecraft:air")
+        air = Block(blockstate="minecraft:air")
 
-        self.assertIsInstance(air, blocks.Block)
+        self.assertIsInstance(air, Block)
         self.assertEqual("minecraft", air.namespace)
         self.assertEqual("air", air.base_name)
         self.assertEqual({}, air.properties)
         self.assertEqual((), air.extra_blocks)
         self.assertEqual("minecraft:air", air.blockstate)
 
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        stone = Block(blockstate="minecraft:stone")
 
-        self.assertIsInstance(stone, blocks.Block)
+        self.assertIsInstance(stone, Block)
         self.assertEqual("minecraft", stone.namespace)
         self.assertEqual("stone", stone.base_name)
         self.assertEqual({}, stone.properties)
@@ -32,11 +32,11 @@ class BlockTestCase(unittest.TestCase):
 
         self.assertNotEqual(air, stone)
 
-        oak_leaves = blocks.Block.get_from_blockstate(
-            "minecraft:oak_leaves[distance=1,persistent=true]"
+        oak_leaves = Block(
+            blockstate="minecraft:oak_leaves[distance=1,persistent=true]"
         )
 
-        self.assertIsInstance(oak_leaves, blocks.Block)
+        self.assertIsInstance(oak_leaves, Block)
         self.assertEqual("minecraft", oak_leaves.namespace)
         self.assertEqual("oak_leaves", oak_leaves.base_name)
         self.assertEqual({"distance": "1", "persistent": "true"}, oak_leaves.properties)
@@ -46,13 +46,13 @@ class BlockTestCase(unittest.TestCase):
         )
 
     def test_extra_blocks(self):
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
-        granite = blocks.Block.get_from_blockstate("minecraft:granite")
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        stone = Block(blockstate="minecraft:stone")
+        water = Block(blockstate="minecraft:water[level=1]")
+        granite = Block(blockstate="minecraft:granite")
+        dirt = Block(blockstate="minecraft:dirt")
 
         conglomerate_1 = stone + water + dirt
-        self.assertIsInstance(conglomerate_1, blocks.Block)
+        self.assertIsInstance(conglomerate_1, Block)
         self.assertEqual("minecraft", conglomerate_1.namespace)
         self.assertEqual("stone", conglomerate_1.base_name)
         self.assertEqual({}, conglomerate_1.properties)
@@ -62,7 +62,7 @@ class BlockTestCase(unittest.TestCase):
             self.assertEqual(0, len(block_1.extra_blocks))
 
         conglomerate_2 = conglomerate_1 + granite
-        self.assertIsInstance(conglomerate_2, blocks.Block)
+        self.assertIsInstance(conglomerate_2, Block)
         self.assertEqual("minecraft", conglomerate_2.namespace)
         self.assertEqual("stone", conglomerate_2.base_name)
         self.assertEqual({}, conglomerate_2.properties)
@@ -76,7 +76,7 @@ class BlockTestCase(unittest.TestCase):
         self.assertNotEqual(conglomerate_1, conglomerate_2)
 
         conglomerate_3 = conglomerate_2 - dirt
-        self.assertIsInstance(conglomerate_3, blocks.Block)
+        self.assertIsInstance(conglomerate_3, Block)
         self.assertEqual("minecraft", conglomerate_3.namespace)
         self.assertEqual("stone", conglomerate_3.base_name)
         self.assertEqual({}, conglomerate_3.properties)
@@ -89,8 +89,8 @@ class BlockTestCase(unittest.TestCase):
         self.assertRaises(TypeError, lambda: stone - 1)
 
     def test_extra_blocks_immutable(self):
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        stone = Block(blockstate="minecraft:stone")
+        dirt = Block(blockstate="minecraft:dirt")
 
         stone2 = stone
         self.assertIs(stone, stone2)
@@ -103,14 +103,14 @@ class BlockTestCase(unittest.TestCase):
         self.assertIsNot(stone, stone3)
 
     def test_remove_layer(self):
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
-        granite = blocks.Block.get_from_blockstate("minecraft:granite")
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
-        oak_log_axis_x = blocks.Block.get_from_blockstate("minecraft:oak_log[axis=x]")
+        stone = Block(blockstate="minecraft:stone")
+        water = Block(blockstate="minecraft:water[level=1]")
+        granite = Block(blockstate="minecraft:granite")
+        dirt = Block(blockstate="minecraft:dirt")
+        oak_log_axis_x = Block(blockstate="minecraft:oak_log[axis=x]")
 
         conglomerate_1 = stone + water + dirt + dirt + granite
-        self.assertIsInstance(conglomerate_1, blocks.Block)
+        self.assertIsInstance(conglomerate_1, Block)
         self.assertEqual("minecraft", conglomerate_1.namespace)
         self.assertEqual("stone", conglomerate_1.base_name)
         self.assertEqual({}, conglomerate_1.properties)
@@ -129,7 +129,7 @@ class BlockTestCase(unittest.TestCase):
             self.assertEqual(0, len(block_1.extra_blocks))
 
         conglomerate_2 = granite + water + stone + dirt + oak_log_axis_x
-        self.assertIsInstance(conglomerate_2, blocks.Block)
+        self.assertIsInstance(conglomerate_2, Block)
         self.assertEqual("minecraft", conglomerate_2.namespace)
         self.assertEqual("granite", conglomerate_2.base_name)
         self.assertEqual({}, conglomerate_2.properties)
@@ -149,10 +149,10 @@ class BlockTestCase(unittest.TestCase):
             self.assertEqual(0, len(block_1.extra_blocks))
 
     def test_hash(self):
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
-        granite = blocks.Block.get_from_blockstate("minecraft:granite")
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+        stone = Block(blockstate="minecraft:stone")
+        water = Block(blockstate="minecraft:water[level=1]")
+        granite = Block(blockstate="minecraft:granite")
+        dirt = Block(blockstate="minecraft:dirt")
 
         conglomerate_1 = stone + water + dirt
         conglomerate_2 = stone + dirt + water
@@ -177,15 +177,13 @@ class BlockTestCase(unittest.TestCase):
 
 class BlockManagerTestCase(unittest.TestCase):
     def setUp(self):
-        self.manager = blocks.BlockManager()
+        self.manager = BlockManager()
 
-        initial_dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
-        initial_stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        initial_granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        initial_dirt = Block(blockstate="minecraft:dirt")
+        initial_stone = Block(blockstate="minecraft:stone")
+        initial_granite = Block(blockstate="minecraft:granite")
 
-        initial_dirt_water = initial_dirt + blocks.Block.get_from_blockstate(
-            "minecraft:water"
-        )
+        initial_dirt_water = initial_dirt + Block(blockstate="minecraft:water")
 
         # Partially populate the manager
         self.manager[initial_dirt]
@@ -194,15 +192,15 @@ class BlockManagerTestCase(unittest.TestCase):
         self.manager[initial_dirt_water]
 
     def test_get_index_from_manager(self):
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        dirt = Block(blockstate="minecraft:dirt")
+        stone = Block(blockstate="minecraft:stone")
+        granite = Block(blockstate="minecraft:granite")
 
         self.assertEqual(0, self.manager[dirt])
         self.assertEqual(1, self.manager[stone])
         self.assertEqual(2, self.manager[granite])
 
-        water = blocks.Block.get_from_blockstate("minecraft:water")
+        water = Block(blockstate="minecraft:water")
 
         dirt_water = dirt + water
 
@@ -211,10 +209,10 @@ class BlockManagerTestCase(unittest.TestCase):
         self.assertEqual(3, self.manager[dirt_water])
 
     def test_get_block_from_manager(self):
-        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
-        stone = blocks.Block.get_from_blockstate("minecraft:stone")
-        granite = blocks.Block.get_from_blockstate("minecraft:granite")
-        water = blocks.Block.get_from_blockstate("minecraft:water")
+        dirt = Block(blockstate="minecraft:dirt")
+        stone = Block(blockstate="minecraft:stone")
+        granite = Block(blockstate="minecraft:granite")
+        water = Block(blockstate="minecraft:water")
         dirt_water = dirt + water
 
         self.assertEqual(dirt, self.manager[0])

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,117 @@
+import sys
+import os
+
+try:
+    import api
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+import unittest
+from api import blocks
+
+
+class BlockTestCase(unittest.TestCase):
+    def test_get_from_blockstate(self):  # This is mostly just sanity checks
+        air = blocks.Block.get_from_blockstate("minecraft:air")
+
+        self.assertIsInstance(air, blocks.Block)
+        self.assertEqual("minecraft", air.namespace)
+        self.assertEqual("air", air.base_name)
+        self.assertEqual({}, air.properties)
+        self.assertEqual((), air.extra_blocks)
+        self.assertEqual("minecraft:air", air.blockstate)
+
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+
+        self.assertIsInstance(stone, blocks.Block)
+        self.assertEqual("minecraft", stone.namespace)
+        self.assertEqual("stone", stone.base_name)
+        self.assertEqual({}, stone.properties)
+        self.assertEqual((), stone.extra_blocks)
+        self.assertEqual("minecraft:stone", stone.blockstate)
+
+        self.assertNotEqual(air, stone)
+
+        oak_leaves = blocks.Block.get_from_blockstate(
+            "minecraft:oak_leaves[distance=1,persistent=true]"
+        )
+
+        self.assertIsInstance(oak_leaves, blocks.Block)
+        self.assertEqual("minecraft", oak_leaves.namespace)
+        self.assertEqual("oak_leaves", oak_leaves.base_name)
+        self.assertEqual({"distance": "1", "persistent": "true"}, oak_leaves.properties)
+        self.assertEqual((), oak_leaves.extra_blocks)
+        self.assertEqual(
+            "minecraft:oak_leaves[distance=1,persistent=true]", oak_leaves.blockstate
+        )
+
+    def test_extra_blocks(self):
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
+        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+
+        conglomerate_1 = stone + water + dirt
+        self.assertIsInstance(conglomerate_1, blocks.Block)
+        self.assertEqual("minecraft", conglomerate_1.namespace)
+        self.assertEqual("stone", conglomerate_1.base_name)
+        self.assertEqual({}, conglomerate_1.properties)
+        self.assertEqual(2, len(conglomerate_1.extra_blocks))
+        for block_1, block_2 in zip(conglomerate_1.extra_blocks, (water, dirt)):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+        conglomerate_2 = conglomerate_1 + granite
+        self.assertIsInstance(conglomerate_2, blocks.Block)
+        self.assertEqual("minecraft", conglomerate_2.namespace)
+        self.assertEqual("stone", conglomerate_2.base_name)
+        self.assertEqual({}, conglomerate_2.properties)
+        self.assertEqual(3, len(conglomerate_2.extra_blocks))
+        for block_1, block_2 in zip(
+            conglomerate_2.extra_blocks, (water, dirt, granite)
+        ):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+        self.assertNotEqual(conglomerate_1, conglomerate_2)
+
+        conglomerate_3 = conglomerate_2 - dirt
+        self.assertIsInstance(conglomerate_3, blocks.Block)
+        self.assertEqual("minecraft", conglomerate_3.namespace)
+        self.assertEqual("stone", conglomerate_3.base_name)
+        self.assertEqual({}, conglomerate_3.properties)
+        self.assertEqual(2, len(conglomerate_3.extra_blocks))
+        print(repr(conglomerate_3))
+        for block_1, block_2 in zip(conglomerate_3.extra_blocks, (water, granite)):
+            self.assertEqual(block_1, block_2)
+            self.assertEqual(0, len(block_1.extra_blocks))
+
+    def test_hash(self):
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")
+        granite = blocks.Block.get_from_blockstate("minecraft:granite")
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+
+        conglomerate_1 = stone + water + dirt
+        conglomerate_2 = stone + dirt + water
+
+        self.assertNotEqual(conglomerate_1, conglomerate_2)
+        self.assertNotEqual(hash(conglomerate_1), hash(conglomerate_2))
+
+        conglomerate_3 = dirt + water + dirt
+        conglomerate_4 = dirt + dirt + water
+
+        self.assertNotEqual(conglomerate_3, conglomerate_4)
+        self.assertNotEqual(hash(conglomerate_3), hash(conglomerate_4))
+
+        conglomerate_5 = conglomerate_1 + granite
+        conglomerate_6 = conglomerate_3 + granite
+
+        self.assertNotEqual(conglomerate_1, conglomerate_5)
+        self.assertNotEqual(conglomerate_3, conglomerate_6)
+        self.assertNotEqual(conglomerate_5, conglomerate_6)
+        self.assertNotEqual(hash(conglomerate_5), hash(conglomerate_6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Block prototype is complete enough to start being implemented into our main codebase. While this won't be started until this pull request is merged, this is pull request is meant to be a place for discussion on the current prototype and to suggest any changes before the implementation stage. All comments and suggestions are welcome.

## Changes
* Blockstates are represented by `Block` objects and in addition to the blockstate, a `Block` object can also have a chain of "extra blocks" as extra data to be used in the Minecraft editions that support it.
   * This chain of extra blocks is a tuple of other `Block` instances
* `Block` objects are created by calling `Block.get_from_blockstate()` with a blockstate string which is parsed via regex (Credit to @freundTech)
* Blocks can be manipulated by the `+` and `-` operators (Examples are in the `Block` class docstring)
    * Once a `Block` object has been created, it should be considered immutable; the `+` and `-` operators along with `Block.remove_layer` will always return a new `Block` object
* Added `BlockManager` which is handler for mapping our index based ID's generated at runtime to `Block` objects and vice-versa
    * Final implementation is still to be decided
* Added `test_blocks.py` for unittests along with examples in `api/blocks.py` when running it as a standalone python script