### PR TITLE
Improved operator support for Blocks

### DIFF
--- a/src/api/blocks.py
+++ b/src/api/blocks.py
@@ -233,6 +233,9 @@ class Block:
         :param other: The Block object to add to the end of this Block object's `extra_blocks`
         :return: A new Block object with the same data but with an additional Block at the end of ``extra_blocks``
         """
+        if not isinstance(other, Block):
+            return NotImplemented
+
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -263,6 +266,9 @@ class Block:
         :param other: The Block object to subtract from this Block objects' ``extra_blocks``
         :return: A new Block object without any instances of the subtracted block in ``extra_blocks``
         """
+        if not isinstance(other, Block):
+            return NotImplemented
+
         if (
             len(other._extra_blocks) == 0
         ):  # Reduces the amount of extra objects/references created
@@ -287,14 +293,6 @@ class Block:
                 new_extras.append(eb)
 
         return Block(self._namespace, self._base_name, self._properties, new_extras)
-
-    def __iadd__(self, other: Block) -> TypeError:
-        raise TypeError("You cannot add an extra block to an already existing block")
-
-    def __isub__(self, other: Block) -> TypeError:
-        raise TypeError(
-            "You cannot subtract an extra block to an already existing block"
-        )
 
 
 class BlockManager:

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -85,6 +85,23 @@ class BlockTestCase(unittest.TestCase):
             self.assertEqual(block_1, block_2)
             self.assertEqual(0, len(block_1.extra_blocks))
 
+        self.assertRaises(TypeError, lambda: stone + 1)
+        self.assertRaises(TypeError, lambda: stone - 1)
+
+    def test_extra_blocks_immutable(self):
+        stone = blocks.Block.get_from_blockstate("minecraft:stone")
+        dirt = blocks.Block.get_from_blockstate("minecraft:dirt")
+
+        stone2 = stone
+        self.assertIs(stone, stone2)
+        stone2 += dirt
+        self.assertIsNot(stone, stone2)
+
+        stone3 = stone2
+        self.assertIs(stone2, stone3)
+        stone3 -= dirt
+        self.assertIsNot(stone, stone3)
+
     def test_remove_layer(self):
         stone = blocks.Block.get_from_blockstate("minecraft:stone")
         water = blocks.Block.get_from_blockstate("minecraft:water[level=1]")


### PR DESCRIPTION
__add__ and __sub__ now return NotImplemented for parameters that aren't
blocks. This allows python to call __radd__ on the other object in case
it support the operation and also produces nicer error messages.

Also removed __iadd__ and __isub__ definitions, so they fall back to
__add__ and __sub__. This still keeps Block immutable.

Tests were added for both changes.

Also see https://github.com/Amulet-Team/Amulet-Map-Editor/pull/24#discussion_r226825398