### PR TITLE
Moved run_operation_from_operation_name from World to OperationCommand

### DIFF
--- a/src/command_line/builtin_commands/operation_command.py
+++ b/src/command_line/builtin_commands/operation_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib import import_module
 from typing import List
 
 from command_line import command, SimpleCommand, parse_coordinates, WorldMode
@@ -37,12 +38,23 @@ class OperationCommand(SimpleCommand):
                 else:
                     options.append(arg)
 
-            error = world.run_operation_from_operation_name(op_name, *options)
-            if error is not None:
-                print(error)
+            operation = self._get_operation(op_name, *options)
+            try:
+                world.run_operation(operation)
+            except Exception as e:
+                print(e)
 
     def help(self):
         pass
 
     def short_help(self) -> str:
         return ""
+
+    @staticmethod
+    def _get_operation(operation_name, *args):
+        operation_module = import_module(f"operations.{operation_name}")
+        operation_class_name = "".join(x.title() for x in operation_name.split("_"))
+        operation_class = getattr(operation_module, operation_class_name)
+        operation_instance = operation_class(*args)
+
+        return operation_instance

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,6 +1,9 @@
 import sys
 import os
 
+from operations.clone import Clone
+from operations.fill import Fill
+
 try:
     import api
 except ModuleNotFoundError:
@@ -75,7 +78,8 @@ class WorldTestBaseCases:
             )  # Sanity check
             self.assertEqual("minecraft:granite", self.world.get_block(1, 70, 5))
 
-            self.world.run_operation_from_operation_name("clone", src_box, target_box)
+            operation = Clone(src_box, target_box)
+            self.world.run_operation(operation)
 
             self.assertEqual("minecraft:stone", self.world.get_block(1, 70, 5))
 
@@ -95,7 +99,8 @@ class WorldTestBaseCases:
             subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
             box = SelectionBox((subbox_1,))
 
-            self.world.run_operation_from_operation_name("fill", box, "minecraft:stone")
+            operation = Fill(box, "minecraft:stone")
+            self.world.run_operation(operation)
 
             for x, y, z in box:
                 self.assertEqual(


### PR DESCRIPTION
`run_operation_from_operation_name` always looked a bit out of place in `World`. In my opinion importing and creating the operation is something that should be done by the class interfacing with `World` instead of by `World` itself.

This is my suggestion to fixing that.