### PR TITLE
Reworked History Manager to use Chunks instead of Operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ venv_37/
 ENV/
 env.bak/
 venv.bak/
+venv*
 
 # Spyder project settings
 .spyderproject

--- a/docs_source/api/chunk.rst
+++ b/docs_source/api/chunk.rst
@@ -1,0 +1,6 @@
+chunk
+=====
+
+.. automodule:: api.chunk
+    :members:
+    :show-inheritance:

--- a/docs_source/api/history_manager.rst
+++ b/docs_source/api/history_manager.rst
@@ -1,0 +1,6 @@
+history_manager
+===============
+
+.. automodule:: api.history_manager
+    :members:
+    :show-inheritance:

--- a/src/api/chunk.py
+++ b/src/api/chunk.py
@@ -84,6 +84,7 @@ class Chunk:
 
     def delete(self):
         self._marked_for_deletion = True
+        self._changed = True
 
     def save_blocks_to_file(self, change_path) -> str:
         save_path = join(change_path, "blocks.npy")

--- a/src/api/chunk.py
+++ b/src/api/chunk.py
@@ -12,6 +12,10 @@ SliceCoordinates = Tuple[slice, slice, slice]
 
 
 class Chunk:
+    """
+    Class to represent a chunk that exists in an Minecraft world
+    """
+
     def __init__(self, cx: int, cz: int, blocks=None, entities=None, tileentities=None):
         self.cx, self.cz = cx, cz
         self._blocks: numpy.ndarray = blocks
@@ -45,14 +49,27 @@ class Chunk:
 
     @property
     def changed(self) -> bool:
+        """
+        :return: ``True`` if the chunk has been changed, ``False`` otherwise
+        """
         return self._changed
 
     @property
     def marked_for_deletion(self) -> bool:
+        """
+        :return: ``True`` if the chunk has been marked for deletion, ``False`` otherwise
+        """
         return self._marked_for_deletion
 
     @property
     def blocks(self) -> numpy.ndarray:
+        """
+        Property that returns a read-only copy of the chunk's block array. Setting this property replaces the entire chunk's block array
+
+        :param value: The new block array
+        :type value: numpy.ndarray
+        :return: A 3d numpy array of the internal Block IDs for the chunk
+        """
         self._blocks.setflags(write=False)
         return self._blocks
 
@@ -63,7 +80,14 @@ class Chunk:
         self._blocks = value
 
     @property
-    def entities(self):
+    def entities(self) -> list:
+        """
+        Property that returns a copy of the chunk's entity list. Setting this property replaces the chunk's entity list
+
+        :param value: The new entity list
+        :type value: list
+        :return: A list of all the entities contained in the chunk
+        """
         return copy.deepcopy(self._entities)
 
     @entities.setter
@@ -73,7 +97,14 @@ class Chunk:
             self._entities = value
 
     @property
-    def tileentities(self):
+    def tileentities(self) -> list:
+        """
+        Property that returns a copy of the chunk's tile entity list. Setting this property replaces the chunk's tile entity list
+
+        :param value: The new tile entity list
+        :type value: list
+        :return: A list of all the tile entities contained in the chunk
+        """
         return copy.deepcopy(self._tileentities)
 
     @tileentities.setter
@@ -83,6 +114,12 @@ class Chunk:
             self._tileentities = value
 
     def serialize_chunk(self, change_path) -> str:
+        """
+        Serialized the chunk to a file on the disk in the supplied directory path. The filename follows the convention: ``<cx>.<cz>.chunk``
+
+        :param change_path: The directory path to save the chunk at
+        :return: The full path to the serialized chunk file
+        """
         save_path = join(change_path, f"{self.cx}.{self.cz}.chunk")
 
         fp = open(save_path, "wb")
@@ -93,6 +130,12 @@ class Chunk:
 
     @classmethod
     def unserialize_chunk(cls, change_path) -> Chunk:
+        """
+        Unserializes chunk from the given file path.
+
+        :param change_path: The file to unserialize
+        :return: The recreated :class:`api.chunk.Chunk` object
+        """
         fp = open(change_path, "rb")
         chunk = pickle.load(fp)
         fp.close()
@@ -100,11 +143,18 @@ class Chunk:
         return chunk
 
     def delete(self):
+        """
+        Marks the given chunk for deletion
+        """
         self._marked_for_deletion = True
         self._changed = True
 
 
 class SubChunk:
+    """
+    Class to represent a sub-selection of a chunk
+    """
+
     def __init__(
         self,
         sub_selection_slice: Union[PointCoordinates, SliceCoordinates],
@@ -114,7 +164,19 @@ class SubChunk:
         self._parent = parent
 
     @property
-    def blocks(self):
+    def parent_coordinates(self) -> Tuple[int, int]:
+        """
+        :return: The chunk x and z coordinates for the parent chunk
+        """
+        return self._parent.cx, self._parent.cz
+
+    @property
+    def blocks(self) -> numpy.ndarray:
+        """
+        :param value: A new numpy array of blocks for the sub-selection
+        :type value: numpy.ndarray
+        :return: A 3d array of blocks in the sub-selection
+        """
         return self._parent.blocks[self._sub_selection_slice]
 
     @blocks.setter

--- a/src/api/chunk.py
+++ b/src/api/chunk.py
@@ -82,31 +82,26 @@ class Chunk:
             self._changed = True
             self._tileentities = value
 
+    def serialize_chunk(self, change_path) -> str:
+        save_path = join(change_path, f"{self.cx}.{self.cz}.chunk")
+
+        fp = open(save_path, "wb")
+        pickle.dump(self, fp)
+        fp.close()
+
+        return save_path
+
+    @classmethod
+    def unserialize_chunk(cls, change_path) -> Chunk:
+        fp = open(change_path, "rb")
+        chunk = pickle.load(fp)
+        fp.close()
+
+        return chunk
+
     def delete(self):
         self._marked_for_deletion = True
         self._changed = True
-
-    def save_blocks_to_file(self, change_path) -> str:
-        save_path = join(change_path, "blocks.npy")
-        numpy.save(save_path, self._blocks, allow_pickle=False, fix_imports=False)
-
-        return save_path
-
-    def save_entities_to_file(self, change_path) -> str:
-        save_path = join(change_path, "entities.pickle")
-        fp = open(save_path, "wb")
-        pickle.dump(self._entities, fp)
-        fp.close()
-
-        return save_path
-
-    def save_tileentities_to_file(self, change_path) -> str:
-        save_path = join(change_path, "tileentities.pickle")
-        fp = open(save_path, "wb")
-        pickle.dump(self._tileentities, fp)
-        fp.close()
-
-        return save_path
 
 
 class SubChunk:

--- a/src/api/errors.py
+++ b/src/api/errors.py
@@ -20,3 +20,7 @@ class FormatLoaderNoneMatched(FormatError):
 
 class InvalidBlockException(Exception):
     pass
+
+
+class ChunkDoesntExistException(Exception):  # Possibly change the name in the future
+    pass

--- a/src/api/history_manager.py
+++ b/src/api/history_manager.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import copy
+from typing import List
+
+import os
+
+import pickle
+
+import numpy
+
+
+class SubChunk2:
+    def __init__(self, sub_selection_slice, parent: Chunk2):
+        self._sub_selection_slice = sub_selection_slice
+        self._parent = parent
+
+    @property
+    def blocks(self):
+        return self._parent.blocks[self._sub_selection_slice]
+
+    @blocks.setter
+    def blocks(self, value):
+        temp_blocks = self._parent.blocks.copy()
+        temp_blocks[self._sub_selection_slice] = value
+        self._parent.blocks = temp_blocks
+
+
+class Chunk2:
+    def __init__(
+        self,
+        cx: int,
+        cz: int,
+        blocks=None,
+        entities=None,
+        tileentities=None,
+        get_blocks_func=None,
+        get_entities_func=None,
+    ):
+        self.cx, self.cz = cx, cz
+        self._blocks: numpy.ndarray = blocks
+        self._entities = entities
+        self._tileentities = tileentities
+
+        self.get_blocks_func = get_blocks_func
+        self.get_entities_func = get_blocks_func
+        self._changed = False
+
+    def __repr__(self):
+        return f"Chunk({self.cx}, {self.cx}, {repr(self._blocks)}, {repr(self._entities)}, {repr(self._tileentities)})"
+
+    def __getitem__(self, item):
+        if (
+            not isinstance(item, tuple)
+            or len(item) != 3
+            or not (
+                isinstance(item[0], int)
+                and isinstance(item[1], int)
+                and isinstance(item[2], int)
+                or (
+                    isinstance(item[0], slice)
+                    and isinstance(item[1], slice)
+                    and isinstance(item[2], slice)
+                )
+            )
+        ):
+            raise Exception(f"The item {item} for Selection object does not make sense")
+
+        return SubChunk2(item, self)
+
+    @property
+    def changed(self):
+        return self._changed
+
+    @property
+    def blocks(self) -> numpy.ndarray:
+        if self._blocks is None:
+            self._blocks = self.get_blocks_func(self.cx, self.cz)
+        self._blocks.setflags(write=False)
+        return self._blocks
+
+    @blocks.setter
+    def blocks(self, value: numpy.ndarray):
+        if not (self._blocks == value).all():
+            self._changed = True
+        self._blocks = value
+
+    @property
+    def entities(self):
+        if self._entities is None:
+            self._entities = self.get_entities_func(self.cx, self.cz)
+
+        return copy.deepcopy(self._entities)
+
+    @entities.setter
+    def entities(self, value):
+        if self._entities != value:
+            self._changed = True
+            self._entities = value
+
+    @property
+    def tileentities(self):
+        return copy.deepcopy(self._tileentities)
+
+    @tileentities.setter
+    def tileentities(self, value):
+        if self._tileentities != value:
+            self._changed = True
+            self._tileentities = value
+
+    def save_blocks_to_file(self, change_no: int, base_path=".") -> str:
+        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
+
+        if not os.path.exists(change_path):
+            os.makedirs(change_path, exist_ok=True)
+
+        save_path = os.path.join(change_path, "blocks.npy")
+        numpy.save(save_path, self._blocks, allow_pickle=False, fix_imports=False)
+
+        return save_path
+
+    def save_entities_to_file(self, change_no: int, base_path=".") -> str:
+        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
+
+        if not os.path.exists(change_path):
+            os.makedirs(change_path, exist_ok=True)
+
+        save_path = os.path.join(change_path, "entities.pickle")
+        fp = open(save_path, "wb")
+        pickle.dump(self._entities, fp)
+        fp.close()
+
+        return save_path
+
+    def save_tileentities_to_file(self, change_no: int, base_path=".") -> str:
+        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
+
+        if not os.path.exists(change_path):
+            os.makedirs(change_path, exist_ok=True)
+
+        save_path = os.path.join(change_path, "tileentities.pickle")
+        fp = open(save_path, "wb")
+        pickle.dump(self._tileentities, fp)
+        fp.close()
+
+        return save_path
+
+
+class ChunkHistoryManager:
+    def __init__(self, work_dir="."):
+        self._history = []
+        self._change_index = 0
+        self.work_dir = work_dir
+
+    def add_changed_chunks(self, chunks: List[Chunk2]):
+        change_no = self._change_index
+        change_manifest = {}
+
+        if change_no < len(self._history):
+            raise NotImplementedError()
+
+        for chunk in chunks:
+            change_manifest[f"{chunk.cx},{chunk.cz}"] = {
+                "blocks": chunk.save_blocks_to_file(change_no, base_path=self.work_dir),
+                "entities": chunk.save_entities_to_file(
+                    change_no, base_path=self.work_dir
+                ),
+                "tileentities": chunk.save_tileentities_to_file(
+                    change_no, base_path=self.work_dir
+                ),
+                "action": "EDIT",
+            }
+            chunk._changed = False
+
+        self._history.append(change_manifest)
+        self._change_index += 1
+
+    def unserialize_chunks(self) -> List[Chunk2]:
+        chunks = []
+
+        for chunk_coords, chunk_manifest in self._history[self._change_index].items():
+            # print(chunk_coords, chunk_manifest)
+            blocks = numpy.load(
+                chunk_manifest["blocks"], allow_pickle=False, fix_imports=False
+            )
+
+            fp = open(chunk_manifest["entities"], "rb")
+            entities = pickle.load(fp)
+            fp.close()
+
+            fp = open(chunk_manifest["tileentities"], "rb")
+            tileentities = pickle.load(fp)
+            fp.close()
+
+            cx, cz = map(int, chunk_coords.split(","))
+
+            chunks.append(Chunk2(cx, cz, blocks, entities, tileentities))
+
+        return chunks
+
+    def undo(self) -> List[Chunk2]:
+        if self._change_index == 0:
+            raise Exception("No more changes to undo")
+        else:
+            self._change_index -= 1
+        return self.unserialize_chunks()
+
+
+"""
+if __name__ == "__main__":
+    hist_manager = ChunkHistoryManager(work_dir="work")
+    c00 = Chunk2(0, 0, blocks=numpy.zeros((16, 256, 16)))
+    c11 = Chunk2(1, 1, blocks=numpy.ones((16, 256, 16)))
+    hist_manager.add_changed_chunks([c00, c11])
+
+    subch00 = c00[0:4,0:4,0:4]
+    subch00.blocks = numpy.full(subch00.blocks.shape, 111, subch00.blocks.dtype)
+    #c11.blocks[0, 0, 0] = 111
+
+    #c00.entities.append("test")
+
+    #raise Exception(c00.changed)
+
+    hist_manager.add_changed_chunks([c00, c11])
+
+    print(hist_manager.undo())
+    print("=" * 32)
+    print(hist_manager.undo())
+"""

--- a/src/api/history_manager.py
+++ b/src/api/history_manager.py
@@ -33,7 +33,7 @@ class ChunkHistoryManager:
         :param chunk: The chunk in it's original state
         """
 
-        self._history[0][(chunk.cx, chunk.cz)] = self.serialize_chunk(chunk, 0)
+        self._history[0][(chunk.cx, chunk.cz)] = self._serialize_chunk(chunk, 0)
 
     def add_changed_chunks(self, chunks: List[Chunk]):
         """
@@ -56,7 +56,7 @@ class ChunkHistoryManager:
         )
 
         for chunk in chunks:
-            change_manifest[(chunk.cx, chunk.cz)] = self.serialize_chunk(
+            change_manifest[(chunk.cx, chunk.cz)] = self._serialize_chunk(
                 chunk, change_no
             )
 
@@ -64,7 +64,7 @@ class ChunkHistoryManager:
 
         return deleted_chunks
 
-    def serialize_chunk(self, chunk: Chunk, change_no: int) -> _ChunkRecord:
+    def _serialize_chunk(self, chunk: Chunk, change_no: int) -> _ChunkRecord:
         """
         Serializes the given ``api.chunk.Chunk`` to disk and returns a tuple containing the path to the chunk file and the type of action performed
 
@@ -87,6 +87,11 @@ class ChunkHistoryManager:
         return serialized_chunk
 
     def _unserialize_chunks(self) -> Tuple[List[Chunk], List[Chunk]]:
+        """
+        Unserializes all of chunks at the given chunk record at :attr:`api.history_manager.ChunkHistoryManager.change_index`
+
+        :return: A tuple of a list of the changed chunks. The first index being edited chunks, the second one being chunks that were deleted
+        """
         edited_chunks = []
         deleted_chunks = []
 

--- a/src/api/history_manager.py
+++ b/src/api/history_manager.py
@@ -1,138 +1,21 @@
 from __future__ import annotations
 
-import copy
 from typing import Dict, List, Tuple
 
-import os
-
 import pickle
+from os import makedirs
+from os.path import exists, join
 
 import numpy
 
+from api.chunk import Chunk
 
-class SubChunk2:
-    def __init__(self, sub_selection_slice, parent: Chunk2):
-        self._sub_selection_slice = sub_selection_slice
-        self._parent = parent
-
-    @property
-    def blocks(self):
-        return self._parent.blocks[self._sub_selection_slice]
-
-    @blocks.setter
-    def blocks(self, value):
-        temp_blocks = self._parent.blocks.copy()
-        temp_blocks[self._sub_selection_slice] = value
-        self._parent.blocks = temp_blocks
-
-
-class Chunk2:
-    def __init__(self, cx: int, cz: int, blocks=None, entities=None, tileentities=None):
-        self.cx, self.cz = cx, cz
-        self._blocks: numpy.ndarray = blocks
-        self._entities = entities
-        self._tileentities = tileentities
-
-        self._changed = False
-
-    def __repr__(self):
-        return f"Chunk({self.cx}, {self.cx}, {repr(self._blocks)}, {repr(self._entities)}, {repr(self._tileentities)})"
-
-    def __getitem__(self, item):
-        if (
-            not isinstance(item, tuple)
-            or len(item) != 3
-            or not (
-                isinstance(item[0], int)
-                and isinstance(item[1], int)
-                and isinstance(item[2], int)
-                or (
-                    isinstance(item[0], slice)
-                    and isinstance(item[1], slice)
-                    and isinstance(item[2], slice)
-                )
-            )
-        ):
-            raise Exception(f"The item {item} for Selection object does not make sense")
-
-        return SubChunk2(item, self)
-
-    @property
-    def changed(self) -> bool:
-        return self._changed
-
-    @property
-    def blocks(self) -> numpy.ndarray:
-        self._blocks.setflags(write=False)
-        return self._blocks
-
-    @blocks.setter
-    def blocks(self, value: numpy.ndarray):
-        if not (self._blocks == value).all():
-            self._changed = True
-        self._blocks = value
-
-    @property
-    def entities(self):
-        return copy.deepcopy(self._entities)
-
-    @entities.setter
-    def entities(self, value):
-        if self._entities != value:
-            self._changed = True
-            self._entities = value
-
-    @property
-    def tileentities(self):
-        return copy.deepcopy(self._tileentities)
-
-    @tileentities.setter
-    def tileentities(self, value):
-        if self._tileentities != value:
-            self._changed = True
-            self._tileentities = value
-
-    def save_blocks_to_file(self, change_no: int, base_path=".") -> str:
-        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
-
-        if not os.path.exists(change_path):
-            os.makedirs(change_path, exist_ok=True)
-
-        save_path = os.path.join(change_path, "blocks.npy")
-        numpy.save(save_path, self._blocks, allow_pickle=False, fix_imports=False)
-
-        return save_path
-
-    def save_entities_to_file(self, change_no: int, base_path=".") -> str:
-        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
-
-        if not os.path.exists(change_path):
-            os.makedirs(change_path, exist_ok=True)
-
-        save_path = os.path.join(change_path, "entities.pickle")
-        fp = open(save_path, "wb")
-        pickle.dump(self._entities, fp)
-        fp.close()
-
-        return save_path
-
-    def save_tileentities_to_file(self, change_no: int, base_path=".") -> str:
-        change_path = os.path.join(base_path, str(change_no), f"{self.cx},{self.cz}")
-
-        if not os.path.exists(change_path):
-            os.makedirs(change_path, exist_ok=True)
-
-        save_path = os.path.join(change_path, "tileentities.pickle")
-        fp = open(save_path, "wb")
-        pickle.dump(self._tileentities, fp)
-        fp.close()
-
-        return save_path
+_ChunkRecord = Tuple[str, str, str, str]
 
 
 class ChunkHistoryManager:
     def __init__(self, work_dir: str = "."):
-        self._history: List[Dict[Tuple[int, int], Dict[str, str]]] = [{}]
+        self._history: List[Dict[Tuple[int, int], _ChunkRecord]] = [{}]
         self._change_index: int = 0
         self.work_dir: str = work_dir
 
@@ -140,11 +23,11 @@ class ChunkHistoryManager:
     def change_index(self) -> int:
         return self._change_index
 
-    def add_original_chunk(self, chunk: Chunk2):
+    def add_original_chunk(self, chunk: Chunk):
 
         self._history[0][(chunk.cx, chunk.cz)] = self.serialize_chunk(chunk, 0)
 
-    def add_changed_chunks(self, chunks: List[Chunk2]):
+    def add_changed_chunks(self, chunks: List[Chunk]):
         self._change_index += 1
         change_no = self._change_index
         change_manifest = {}
@@ -162,71 +45,60 @@ class ChunkHistoryManager:
 
         self._history.append(change_manifest)
 
-    def serialize_chunk(self, chunk: Chunk2, change_no: int) -> Dict[str, str]:
-        serialized_chunk = {
-            "blocks": chunk.save_blocks_to_file(change_no, base_path=self.work_dir),
-            "entities": chunk.save_entities_to_file(change_no, base_path=self.work_dir),
-            "tileentities": chunk.save_tileentities_to_file(
-                change_no, base_path=self.work_dir
-            ),
-            "action": "EDIT",
-        }
+    def serialize_chunk(self, chunk: Chunk, change_no: int) -> _ChunkRecord:
+        change_path = join(self.work_dir, str(change_no), f"{chunk.cx},{chunk.cz}")
+
+        if not exists(change_path):
+            makedirs(change_path, exist_ok=True)
+
+        serialized_chunk = (
+            chunk.save_blocks_to_file(change_path),
+            chunk.save_entities_to_file(change_path),
+            chunk.save_tileentities_to_file(change_path),
+            "DELETE" if chunk.marked_for_deletion else "EDIT",
+        )
         chunk._changed = False
+
         return serialized_chunk
 
-    def _unserialize_chunks(self) -> List[Chunk2]:
-        chunks = []
+    def _unserialize_chunks(self) -> Tuple[List[Chunk], List[Chunk]]:
+        edited_chunks = []
+        deleted_chunks = []
 
         for chunk_coords, chunk_manifest in self._history[self._change_index].items():
             blocks = numpy.load(
-                chunk_manifest["blocks"], allow_pickle=False, fix_imports=False
+                chunk_manifest[0], allow_pickle=False, fix_imports=False
             )
 
-            fp = open(chunk_manifest["entities"], "rb")
+            fp = open(chunk_manifest[1], "rb")
             entities = pickle.load(fp)
             fp.close()
 
-            fp = open(chunk_manifest["tileentities"], "rb")
+            fp = open(chunk_manifest[2], "rb")
             tileentities = pickle.load(fp)
             fp.close()
 
-            chunks.append(Chunk2(*chunk_coords, blocks, entities, tileentities))
+            if chunk_manifest[3] == "DELETE":
+                deleted_chunks.append(
+                    Chunk(*chunk_coords, blocks, entities, tileentities)
+                )
+            else:
+                edited_chunks.append(
+                    Chunk(*chunk_coords, blocks, entities, tileentities)
+                )
 
-        return chunks
+        return edited_chunks, deleted_chunks
 
-    def undo(self) -> List[Chunk2]:
+    def undo(self) -> Tuple[List[Chunk], List[Chunk]]:
         if self._change_index == 0:
             raise Exception("No more changes to undo")
         else:
             self._change_index -= 1
         return self._unserialize_chunks()
 
-    def redo(self) -> List[Chunk2]:
+    def redo(self) -> Tuple[List[Chunk], List[Chunk]]:
         if self._change_index == (len(self._history) - 1):
             raise Exception("No more changes to redo")
         else:
             self._change_index += 1
         return self._unserialize_chunks()
-
-
-"""
-if __name__ == "__main__":
-    hist_manager = ChunkHistoryManager(work_dir="work")
-    c00 = Chunk2(0, 0, blocks=numpy.zeros((16, 256, 16)))
-    c11 = Chunk2(1, 1, blocks=numpy.ones((16, 256, 16)))
-    hist_manager.add_changed_chunks([c00, c11])
-
-    subch00 = c00[0:4,0:4,0:4]
-    subch00.blocks = numpy.full(subch00.blocks.shape, 111, subch00.blocks.dtype)
-    #c11.blocks[0, 0, 0] = 111
-
-    #c00.entities.append("test")
-
-    #raise Exception(c00.changed)
-
-    hist_manager.add_changed_chunks([c00, c11])
-
-    print(hist_manager.undo())
-    print("=" * 32)
-    print(hist_manager.undo())
-"""

--- a/src/api/history_manager.py
+++ b/src/api/history_manager.py
@@ -38,12 +38,18 @@ class ChunkHistoryManager:
         if change_no == 0:
             raise NotImplementedError()
 
+        deleted_chunks = map(
+            lambda c: (c.cx, c.cz), filter(lambda c: c.marked_for_deletion, chunks)
+        )
+
         for chunk in chunks:
             change_manifest[(chunk.cx, chunk.cz)] = self.serialize_chunk(
                 chunk, change_no
             )
 
         self._history.append(change_manifest)
+
+        return deleted_chunks
 
     def serialize_chunk(self, chunk: Chunk, change_no: int) -> _ChunkRecord:
         change_path = join(self.work_dir, str(change_no), f"{chunk.cx},{chunk.cz}")

--- a/src/operations/delete_chunk.py
+++ b/src/operations/delete_chunk.py
@@ -11,7 +11,7 @@ class DeleteChunk(Operation):
         for subbox in self.source_box.subboxes():
             sub_chunks = world.get_sub_chunks(*subbox.to_slice())
             for sub_chunk in sub_chunks:
-                chunk_coords = (sub_chunk._parent.cx, sub_chunk._parent.cz)
+                chunk_coords = sub_chunk.parent_coordinates
                 if chunk_coords in already_deleted_chunks:
                     continue
                 sub_chunk._parent.delete()

--- a/src/operations/delete_chunk.py
+++ b/src/operations/delete_chunk.py
@@ -1,0 +1,18 @@
+from api.selection import SelectionBox
+from api.operation import Operation
+
+class DeleteChunk(Operation):
+
+    def __init__(self, source_box: SelectionBox):
+        self.source_box = source_box
+
+    def run_operation(self, world):
+        already_deleted_chunks = set()
+        for subbox in self.source_box.subboxes():
+            sub_chunks = world.get_sub_chunks(*subbox.to_slice())
+            for sub_chunk in sub_chunks:
+                chunk_coords = (sub_chunk._parent.cx, sub_chunk._parent.cz)
+                if chunk_coords in already_deleted_chunks:
+                    continue
+                sub_chunk._parent.delete()
+                already_deleted_chunks.add(chunk_coords)

--- a/src/operations/delete_chunk.py
+++ b/src/operations/delete_chunk.py
@@ -1,8 +1,8 @@
 from api.selection import SelectionBox
 from api.operation import Operation
 
-class DeleteChunk(Operation):
 
+class DeleteChunk(Operation):
     def __init__(self, source_box: SelectionBox):
         self.source_box = source_box
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import time
 from contextlib import contextmanager
@@ -14,7 +15,7 @@ def get_data_path(name: str) -> str:
 
 
 @contextmanager
-def timeout(test_instance, time_constraint: float):
+def timeout(test_instance, time_constraint: float, show_completion_time=False):
     start = time.time()
     yield
 
@@ -23,4 +24,9 @@ def timeout(test_instance, time_constraint: float):
     if delta > time_constraint:
         test_instance.fail(
             f"Test execution didn't meet desired run time of {time_constraint}, ran in {delta} instead"
+        )
+    elif show_completion_time:
+        print(
+            f"Test ran in {delta} seconds, was required to run in {time_constraint} seconds",
+            file=sys.stderr,
         )

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -15,7 +15,6 @@ from api.block import Block
 from api.selection import SubBox, SelectionBox
 from api.chunk import SubChunk, Chunk
 from api import world_loader
-from api.history_manager import Chunk2, SubChunk2
 from api.nbt_template import NBTEntry, NBTCompoundEntry, NBTListEntry
 from formats.anvil2.anvil2_world import _decode_long_array, _encode_long_array
 from test_utils import get_world_path, get_data_path, timeout

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -15,6 +15,8 @@ from api.block import Block
 from api.selection import SubBox, SelectionBox
 from api.chunk import SubChunk
 from api import world_loader
+from api.history_manager import Chunk2, SubChunk2
+from api.nbt_template import NBTEntry, NBTCompoundEntry, NBTListEntry
 from formats.anvil2.anvil2_world import _decode_long_array, _encode_long_array
 from test_utils import get_world_path, get_data_path
 
@@ -49,13 +51,15 @@ class WorldTestBaseCases:
                 next(
                     self.world.get_sub_chunks(slice(0, 10), slice(0, 10), slice(0, 10))
                 ),
-                SubChunk,
+                (SubChunk, SubChunk2),
             )
             self.assertIsInstance(
-                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10)), SubChunk
+                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10)),
+                (SubChunk, SubChunk2),
             )
             self.assertIsInstance(
-                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10, 2, 2, 2)), SubChunk
+                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10, 2, 2, 2)),
+                (SubChunk, SubChunk2),
             )
 
             with self.assertRaises(IndexError):
@@ -94,6 +98,7 @@ class WorldTestBaseCases:
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )
 
+            """
             self.world.redo()
 
             self.assertEqual(
@@ -105,10 +110,20 @@ class WorldTestBaseCases:
             self.assertEqual(
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )
+            """
 
         def test_fill_operation(self):
             subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
             box = SelectionBox((subbox_1,))
+
+            # Start sanity check
+            self.assertEqual(
+                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+            )
+            self.assertEqual(
+                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+            )
+            # End sanity check
 
             self.world.run_operation_from_operation_name(
                 "fill", box, Block("minecraft:stone")
@@ -126,6 +141,7 @@ class WorldTestBaseCases:
             self.assertEqual(
                 "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
             )
+            print(self.world.get_block(1, 70, 5).blockstate)
             self.assertEqual(
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -98,7 +98,6 @@ class WorldTestBaseCases:
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )
 
-            """
             self.world.redo()
 
             self.assertEqual(
@@ -110,7 +109,6 @@ class WorldTestBaseCases:
             self.assertEqual(
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )
-            """
 
         def test_fill_operation(self):
             subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
@@ -141,7 +139,7 @@ class WorldTestBaseCases:
             self.assertEqual(
                 "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
             )
-            print(self.world.get_block(1, 70, 5).blockstate)
+
             self.assertEqual(
                 "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
             )

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -12,8 +12,9 @@ import json
 import numpy
 
 from api.block import Block
+from api.errors import ChunkDoesntExistException
 from api.selection import SubBox, SelectionBox
-from api.chunk import SubChunk, Chunk
+from api.chunk import SubChunk
 from api import world_loader
 from api.nbt_template import NBTEntry, NBTCompoundEntry, NBTListEntry
 from formats.anvil2.anvil2_world import _decode_long_array, _encode_long_array
@@ -70,7 +71,7 @@ class WorldTestBaseCases:
                 next(self.world.get_sub_chunks(0, 0, 0))
 
         def test_clone_operation(self):
-            with timeout(self, 0.25, show_completion_time=True):
+            with timeout(self, 0.5, show_completion_time=True):
                 subbx1 = SubBox((1, 70, 3), (1, 70, 4))
                 src_box = SelectionBox((subbx1,))
 
@@ -111,7 +112,7 @@ class WorldTestBaseCases:
                 )
 
         def test_fill_operation(self):
-            with timeout(self, 0.25):
+            with timeout(self, 0.5, show_completion_time=True):
                 subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
                 box = SelectionBox((subbox_1,))
 
@@ -145,6 +146,54 @@ class WorldTestBaseCases:
                     "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
                 )
 
+                self.world.redo()
+
+                for x, y, z in box:
+                    self.assertEqual(
+                        "minecraft:stone",
+                        self.world.get_block(x, y, z).blockstate,
+                        f"Failed at coordinate ({x},{y},{z})",
+                    )
+
+        def test_delete_chunk(self):
+            subbox1 = SubBox((1, 1, 1), (5, 5, 5))
+            box1 = SelectionBox((subbox1,))
+
+            self.assertEqual(
+                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+            )
+            self.assertEqual(
+                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+            )
+
+            self.world.run_operation_from_operation_name("delete_chunk", box1)
+
+            with self.assertRaises(ChunkDoesntExistException):
+                _ = self.world.get_block(1, 70, 3).blockstate
+
+            self.assertEqual(
+                0, len([x for x in self.world.get_sub_chunks(*subbox1.to_slice())])
+            )
+
+            self.world.undo()
+
+            self.assertEqual(
+                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+            )
+            self.assertEqual(
+                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+            )
+
+            self.world.redo()
+
+            with self.assertRaises(ChunkDoesntExistException):
+                _ = self.world.get_block(1, 70, 3).blockstate
+
+            self.assertEqual(
+                0, len([x for x in self.world.get_sub_chunks(*subbox1.to_slice())])
+            )
+
+        @unittest.skip
         def test_get_entities(
             self
         ):  # TODO: Make a more complete test once we figure out what get_entities() returns

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -13,12 +13,12 @@ import numpy
 
 from api.block import Block
 from api.selection import SubBox, SelectionBox
-from api.chunk import SubChunk
+from api.chunk import SubChunk, Chunk
 from api import world_loader
 from api.history_manager import Chunk2, SubChunk2
 from api.nbt_template import NBTEntry, NBTCompoundEntry, NBTListEntry
 from formats.anvil2.anvil2_world import _decode_long_array, _encode_long_array
-from test_utils import get_world_path, get_data_path
+from test_utils import get_world_path, get_data_path, timeout
 
 
 class WorldTestBaseCases:
@@ -51,15 +51,13 @@ class WorldTestBaseCases:
                 next(
                     self.world.get_sub_chunks(slice(0, 10), slice(0, 10), slice(0, 10))
                 ),
-                (SubChunk, SubChunk2),
+                SubChunk,
             )
             self.assertIsInstance(
-                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10)),
-                (SubChunk, SubChunk2),
+                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10)), SubChunk
             )
             self.assertIsInstance(
-                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10, 2, 2, 2)),
-                (SubChunk, SubChunk2),
+                next(self.world.get_sub_chunks(0, 0, 0, 10, 10, 10, 2, 2, 2)), SubChunk
             )
 
             with self.assertRaises(IndexError):
@@ -73,76 +71,80 @@ class WorldTestBaseCases:
                 next(self.world.get_sub_chunks(0, 0, 0))
 
         def test_clone_operation(self):
-            subbx1 = SubBox((1, 70, 3), (1, 70, 4))
-            src_box = SelectionBox((subbx1,))
+            with timeout(self, 0.25, show_completion_time=True):
+                subbx1 = SubBox((1, 70, 3), (1, 70, 4))
+                src_box = SelectionBox((subbx1,))
 
-            subbx2 = SubBox((1, 70, 5), (1, 70, 6))
-            target_box = SelectionBox((subbx2,))
+                subbx2 = SubBox((1, 70, 5), (1, 70, 6))
+                target_box = SelectionBox((subbx2,))
 
-            self.assertEqual(
-                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
-            )  # Sanity check
-            self.assertEqual(
-                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
-            )
-
-            self.world.run_operation_from_operation_name("clone", src_box, target_box)
-
-            self.assertEqual(
-                "minecraft:stone", self.world.get_block(1, 70, 5).blockstate
-            )
-
-            self.world.undo()
-
-            self.assertEqual(
-                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
-            )
-
-            self.world.redo()
-
-            self.assertEqual(
-                "minecraft:stone", self.world.get_block(1, 70, 5).blockstate
-            )
-
-            self.world.undo()
-
-            self.assertEqual(
-                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
-            )
-
-        def test_fill_operation(self):
-            subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
-            box = SelectionBox((subbox_1,))
-
-            # Start sanity check
-            self.assertEqual(
-                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
-            )
-            self.assertEqual(
-                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
-            )
-            # End sanity check
-
-            self.world.run_operation_from_operation_name(
-                "fill", box, Block("minecraft:stone")
-            )
-
-            for x, y, z in box:
                 self.assertEqual(
-                    "minecraft:stone",
-                    self.world.get_block(x, y, z).blockstate,
-                    f"Failed at coordinate ({x},{y},{z})",
+                    "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+                )  # Sanity check
+                self.assertEqual(
+                    "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
                 )
 
-            self.world.undo()
+                self.world.run_operation_from_operation_name(
+                    "clone", src_box, target_box
+                )
 
-            self.assertEqual(
-                "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
-            )
+                self.assertEqual(
+                    "minecraft:stone", self.world.get_block(1, 70, 5).blockstate
+                )
 
-            self.assertEqual(
-                "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
-            )
+                self.world.undo()
+
+                self.assertEqual(
+                    "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+                )
+
+                self.world.redo()
+
+                self.assertEqual(
+                    "minecraft:stone", self.world.get_block(1, 70, 5).blockstate
+                )
+
+                self.world.undo()
+
+                self.assertEqual(
+                    "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+                )
+
+        def test_fill_operation(self):
+            with timeout(self, 0.25):
+                subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
+                box = SelectionBox((subbox_1,))
+
+                # Start sanity check
+                self.assertEqual(
+                    "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+                )
+                self.assertEqual(
+                    "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+                )
+                # End sanity check
+
+                self.world.run_operation_from_operation_name(
+                    "fill", box, Block("minecraft:stone")
+                )
+
+                for x, y, z in box:
+                    self.assertEqual(
+                        "minecraft:stone",
+                        self.world.get_block(x, y, z).blockstate,
+                        f"Failed at coordinate ({x},{y},{z})",
+                    )
+
+                self.world.undo()
+
+                self.assertEqual(
+                    "minecraft:stone", self.world.get_block(1, 70, 3).blockstate
+                )
+
+                self.assertEqual(
+                    "minecraft:granite", self.world.get_block(1, 70, 5).blockstate
+                )
 
         def test_get_entities(
             self

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -71,7 +71,7 @@ class WorldTestBaseCases:
                 next(self.world.get_sub_chunks(0, 0, 0))
 
         def test_clone_operation(self):
-            with timeout(self, 0.5, show_completion_time=True):
+            with timeout(self, 0.25, show_completion_time=True):
                 subbx1 = SubBox((1, 70, 3), (1, 70, 4))
                 src_box = SelectionBox((subbx1,))
 
@@ -112,7 +112,7 @@ class WorldTestBaseCases:
                 )
 
         def test_fill_operation(self):
-            with timeout(self, 0.5, show_completion_time=True):
+            with timeout(self, 0.25, show_completion_time=True):
                 subbox_1 = SubBox((1, 70, 3), (5, 71, 5))
                 box = SelectionBox((subbox_1,))
 


### PR DESCRIPTION
Modified the history manager for Amulet worlds backup the entirety of each chunk's data to disk after every operation completion or after one/multiple changes are made. This is handled internally by the history manager and the chunk's themselves.

### Changes
- `Chunk` objects now hold their data immediately when created
    - In charge of serializing/unserializing themselves from a file via the `pickle` library
- `ChunkHistoryManager` is now a list of dictionaries that maps chunk coordinates to tuples containing the path to the pickled chunk data and the chunk operation performed (IE: delete or edit)
- `undo()`/`redo()` now update the internal `World.chunk_cache` dictionary with the changed chunk data
- Added a "Delete chunks" operation to test how deleting chunks works with undo/redo and added tests to ensure deleted chunks can be undone
   - Deleted chunks are removed from the internal chunk cache and raise errors when `get_block()` is used within a deleted chunk. For `get_sub_chunks()`, a flag was added to ignore deleted chunks, which is set by default

Anticipated Merge Date: April 11th, 2019