### PR TITLE
Mac Fixes

### DIFF
--- a/amulet_map_editor/amulet_wx/world_select.py
+++ b/amulet_map_editor/amulet_wx/world_select.py
@@ -78,7 +78,7 @@ class WorldUI(simple.SimplePanel):
             wx.ID_ANY,
             '\n'.join([
                 world.world_name,
-                'Unknown', # world.game_version_string,
+                world.game_version_string,
                 os.path.join(*os.path.normpath(path).split(os.sep)[-3:])
             ]),
             wx.DefaultPosition,

--- a/amulet_map_editor/amulet_wx/world_select.py
+++ b/amulet_map_editor/amulet_wx/world_select.py
@@ -1,6 +1,7 @@
 import os
 import wx
 import glob
+from sys import platform
 from typing import List, Dict, Tuple, Callable
 from amulet_map_editor import lang, config
 from amulet import world_interface
@@ -11,15 +12,23 @@ from amulet_map_editor import log
 # macOS 	~/Library/Application Support/minecraft
 # Linux 	~/.minecraft
 
-java_dir = os.path.join(os.getenv('APPDATA'), '.minecraft', 'saves')
-bedrock_dir = os.path.join(os.getenv('LOCALAPPDATA'), 'Packages', 'Microsoft.MinecraftUWP_8wekyb3d8bbwe', 'LocalState', 'games', 'com.mojang', 'minecraftWorlds')
-# TODO: handle other OSs
+def get_java_dir():
+    if platform == "win32":
+        return os.path.join(os.getenv('APPDATA'), '.minecraft')
+    elif platform == "darwin":
+        return os.path.expanduser('~/Library/Application Support/minecraft')
+    else:
+        return os.path.expanduser('~/.minecraft')
 
+def get_java_saves_dir():
+    return os.path.join(get_java_dir(), 'saves')
 
 minecraft_world_paths = {
-    lang.get('java_platform'): java_dir,
-    lang.get('bedrock_platform'): bedrock_dir
+    lang.get('java_platform'): get_java_saves_dir()
 }
+
+if platform == "win32":
+    minecraft_world_paths[lang.get('bedrock_platform')] = os.path.join(os.getenv('LOCALAPPDATA'), 'Packages', 'Microsoft.MinecraftUWP_8wekyb3d8bbwe', 'LocalState', 'games', 'com.mojang', 'minecraftWorlds')
 
 world_images: Dict[str, Tuple[int, wx.Bitmap, int]] = {}
 
@@ -69,7 +78,7 @@ class WorldUI(simple.SimplePanel):
             wx.ID_ANY,
             '\n'.join([
                 world.world_name,
-                world.game_version_string,
+                'Unknown', # world.game_version_string,
                 os.path.join(*os.path.normpath(path).split(os.sep)[-3:])
             ]),
             wx.DefaultPosition,

--- a/amulet_map_editor/opengl/resource_pack.py
+++ b/amulet_map_editor/opengl/resource_pack.py
@@ -35,11 +35,14 @@ class ResourcePackManager:
         self._block_models.clear()
 
     def _set_shader_texture(self, texture: Any):
+        vao = glGenVertexArrays(1)
+        glBindVertexArray(vao)
         shader = shaders.get_shader(self.context_identifier, 'render_chunk')
         glUseProgram(shader)
         glActiveTexture(GL_TEXTURE0)
         glBindTexture(GL_TEXTURE_2D, texture)
         glUniform1i(glGetUniformLocation(shader, 'image'), 0)
+        glBindVertexArray(0)
 
     def get_texture_bounds(self, texture):
         if texture not in self._texture_bounds:

--- a/amulet_map_editor/opengl/textureatlas.py
+++ b/amulet_map_editor/opengl/textureatlas.py
@@ -152,7 +152,10 @@ class Frame(Packable):
         self._filename = filename
 
         # Determine frame dimensions
-        self._image: Image.Image = Image.open(filename)
+        image: Image.Image = Image.open(filename)
+        self._image: Image.Image = image.copy()
+        image.close()
+
         width, height = self._image.size
 
         super(Frame, self).__init__(width, height)


### PR DESCRIPTION
This branch includes a series of misc. things to get the editor running on Mac without errors:

- Path selection in `world_select.py` is based on current platform
- Rendering issues required a VAO to be bound (unsure the ramifications here)
- Errors with too many files being opened resolved by closing the files