### PR TITLE
Fixed Travis CI Build Process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,16 @@ matrix:
     - os: linux
     - os: osx
 
-if: branch IN (master, dev) OR tag =~ ^v(\d*\.\d*)*$
+if: branch = master
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then choco install python --version 3.7.5; fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then python -m pip install --upgrade pip ; fi
   - git config --global user.email ${USER_EMAIL}
   - git config --global user.name ${USER_NAME}
-  - if [[ -z "$TRAVIS_TAG" ]]; then export TRAVIS_TAG="$(git describe --abbrev=0 --tags --exclude *-travis-*)-travis-${TRAVIS_COMMIT:0:7}" ; fi
+  - export TRAVIS_TAG="v$(cat ./amulet_map_editor/version)"
+  - if [ $(git tag -l "${TRAVIS_TAG}") ] ; then travis_terminate 1 ; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then choco install python --version 3.7.5; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then python -m pip install --upgrade pip ; fi
   - export ZIPFILE_NAME="Amulet-${TRAVIS_TAG}-${TRAVIS_OS_NAME}"
-  - export AMULET_MAP_EDITOR_VERSION=${TRAVIS_TAG:1}
-  - git remote add gh https://${TRAVIS_REPO_SLUG%/*}:${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-  - while read in ; do if [ "$TRAVIS_TAG" != "$in" ] ; then git tag --delete $in && git push gh :refs/tags/$in; fi ; done < <(git tag -l *-travis-*)
-  - git remote remove gh
 
 install:
   - pip3 install --upgrade pip
@@ -49,19 +46,7 @@ deploy:
     skip_cleanup: true
     file_glob: true
     file: '*.zip'
-    on:
-      all_branches: true
-      condition: $TRAVIS_TAG =~ ^v[0-9]+\.?[0-9]*\.?[0-9]*$
-  - provider: releases
-    api_key: $GITHUB_TOKEN
-    name: "Amulet $TRAVIS_TAG"
-    prerelease: true
-    skip_cleanup: true
-    file_glob: true
-    file: '*.zip'
-    on:
-      all_branches: true
-      condition: $TRAVIS_TAG =~ ^v[0-9]+\.?[0-9]*\.?[0-9]*-travis-[a-f0-9]{7}$
+    tag_name: $TRAVIS_TAG
 
 notifications:
   email: false

--- a/Amulet.spec
+++ b/Amulet.spec
@@ -15,10 +15,6 @@ import minecraft_model_reader
 
 sys.modules['FixTk'] = None
 
-AMULET_VERSION = os.environ.get("AMULET_MAP_EDITOR_VERSION", "-1.0")
-with open('amulet_map_editor/version', 'w') as f:
-    f.write(AMULET_VERSION)
-
 AMULET_PATH = amulet.__path__[0]
 PYMCT_PATH = os.path.abspath(os.path.dirname(PyMCTranslate.__file__))
 REAL_PYMCT_PATH = PYMCT_PATH if not os.path.islink(PYMCT_PATH) else os.readlink(PYMCT_PATH)  # I have this linked by a symbolic link


### PR DESCRIPTION
Travis builds are now only triggered when both of the following conditions are met:
- The commit was pushed to the `master` branch
- The contents of the `amulet_map_editor/version` file have changed and that there are no existing tags that have the value `v<version>` where `<version>` is the contents of the file