### PR TITLE
Pin git dependencies in requirements_base.txt

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 numpy==1.17.4
 pyopengl==3.1.5
-git+git://github.com/Amulet-Team/Amulet-Core.git
-git+git://github.com/Amulet-Team/Amulet-NBT.git
-git+git://github.com/gentlegiantJGC/PyMCTranslate.git
-git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git
+git+git://github.com/Amulet-Team/Amulet-Core.git@4986e49c143abded07e548b486d71c5085a77d41
+git+git://github.com/Amulet-Team/Amulet-NBT.git@138a71cb1245b07b9a9afd8dfca6ac73bd659a78
+git+git://github.com/gentlegiantJGC/PyMCTranslate.git@1d4601f85f994af230f979e419bd871ae68ba5c5
+git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git@7b2a2fe8b04ff742c57fec41bfdd38bc97b1996e


### PR DESCRIPTION
This helps make the build reproducible; see https://reproducible-builds.org/. This has all kinds of benefits - it ensures that tests are reproducible across runs, makes `git bisect` work properly, makes sure that all published binary artifacts of a given version number ship with the same dependencies, and improves the security of the build process (as well as helps anyone who wants to verify that the published binary artifacts truly correspond to the published source code).

Note that this PR does not *entirely* make the builds reproducible, however, since I believe the dependencies whose specifications are fixed in this patch have the same issue. But it's a good start! If there's interest in this I will look into pinning those components as well.

One concern here is that it may be cumbersome to update these hashes - I can whip up a script to do this automatically if desired. I _did_ test that `pip3 install -r requirements_base.txt` (`requirements_linux.txt` references a wheel that, according to Pip, "is not a supported wheel on this platform"). I did not run the full test suite since I figured that a) this doesn't touch any actual code and b) Travis will do that for me anyway.