### PR TITLE
Fix invalid Pip VCS requirement specs

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 numpy==1.17.4
 pyopengl==3.1.5
-git+git://github.com/Amulet-Team/Amulet-Core.git
-git+git://github.com/Amulet-Team/Amulet-NBT.git
-git+git://github.com/gentlegiantJGC/PyMCTranslate.git
-git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git
+git+git://github.com/Amulet-Team/Amulet-Core.git@4986e49c143abded07e548b486d71c5085a77d41
+git+git://github.com/Amulet-Team/Amulet-NBT.git@138a71cb1245b07b9a9afd8dfca6ac73bd659a78
+git+git://github.com/gentlegiantJGC/PyMCTranslate.git@1d4601f85f994af230f979e419bd871ae68ba5c5
+git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git@7b2a2fe8b04ff742c57fec41bfdd38bc97b1996e

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 numpy==1.17.4
 pyopengl==3.1.5
-git+git://github.com/Amulet-Team/Amulet-Core.git@4986e49c143abded07e548b486d71c5085a77d41
-git+git://github.com/Amulet-Team/Amulet-NBT.git@138a71cb1245b07b9a9afd8dfca6ac73bd659a78
-git+git://github.com/gentlegiantJGC/PyMCTranslate.git@1d4601f85f994af230f979e419bd871ae68ba5c5
-git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git@7b2a2fe8b04ff742c57fec41bfdd38bc97b1996e
+git+git://github.com/Amulet-Team/Amulet-Core.git@4986e49c143abded07e548b486d71c5085a77d41#egg=amulet-core
+git+git://github.com/Amulet-Team/Amulet-NBT.git@138a71cb1245b07b9a9afd8dfca6ac73bd659a78#egg=amulet-nbt
+git+git://github.com/gentlegiantJGC/PyMCTranslate.git@1d4601f85f994af230f979e419bd871ae68ba5c5#egg=pymctranslate
+git+git://github.com/gentlegiantJGC/Minecraft-Model-Reader.git@7b2a2fe8b04ff742c57fec41bfdd38bc97b1996e#egg=minecraft-model-reader


### PR DESCRIPTION
We add `#egg=<pkgname>` at the end of all these to make the specification valid. See https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support for details.

I have verified that `pip3 install -r requirements_base.txt` works OK after this change. Note also that this is based on PR #59 because otherwise there would be merge conflicts. If there's stuff that needs to be addressed in #59 though I'd be happy to rebase this patch on `master` so #59 can land on top of this PR instead of the other way around.

Fixes #62