### PR TITLE
Make this a Pip-installable package (+ other misc fixes)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2020 Amulet Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/amulet_map_editor/__init__.py
+++ b/amulet_map_editor/__init__.py
@@ -3,6 +3,16 @@ from .util.log import log
 from . import lang
 import os
 
+__description__ = 'A new Minecraft world editor and converter that supports all versions since Java 1.12 and Bedrock 1.7'
+__url__ = "https://www.amulet-editor.com/"
+__uri__ = __url__
+__doc__ = __description__ + " <" + __uri__ + ">"
+
+__author__ = 'Amulet Team'
+
+__license__ = "MIT"
+__copyright__ = "Copyright (c) 2018-2020 Amulet Team"
+
 _version_path = os.path.join(os.path.dirname(__file__), 'version')
 if os.path.isfile(_version_path):
     with open(_version_path) as _f:

--- a/amulet_map_editor/load.py
+++ b/amulet_map_editor/load.py
@@ -1,0 +1,20 @@
+# Main application entry point.
+# It is split off from toplevel `main.py` so that the wrapper scripts that setuptools creates can call it
+# These scripts are created automatically when the application is installed as a Pip package.
+
+import wx
+from .amulet_ui import AmuletMainWindow
+from . import log
+import traceback
+
+
+def run():
+    try:
+        app = wx.App()
+        frame = AmuletMainWindow(None)
+        app.MainLoop()
+    except Exception as e:
+        log.critical(
+            f"Amulet Crashed. Sorry about that. Please report it to a developer if you think this is an issue. \n{traceback.format_exc()}"
+        )
+        input("Press ENTER to continue.")

--- a/main.py
+++ b/main.py
@@ -1,15 +1,6 @@
 #!/usr/bin/env python3
 
-import wx
-from amulet_map_editor.amulet_ui import AmuletMainWindow
-from amulet_map_editor import log
-import traceback
+from amulet_map_editor.load import run
 
 if __name__ == "__main__":
-    try:
-        app = wx.App()
-        frame = AmuletMainWindow(None)
-        app.MainLoop()
-    except Exception as e:
-        log.critical(f'Amulet Crashed. Sorry about that. Please report it to a developer if you think this is an issue. \n{traceback.format_exc()}')
-        input("Press ENTER to continue.")
+    run()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import wx
 from amulet_map_editor.amulet_ui import AmuletMainWindow
 from amulet_map_editor import log

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,84 @@
+import codecs
+import os
+import re
+
+from setuptools import setup, find_packages
+
+
+###################################################################
+
+NAME = "amulet-map-editor"
+PACKAGES = find_packages()
+META_PATH = os.path.join("amulet_map_editor", "__init__.py")
+KEYWORDS = ["minecraft", "map editor"]
+CLASSIFIERS = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: End Users/Desktop",
+    "Natural Language :: English",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Games/Entertainment",
+    "Private :: Do Not Upload",
+]
+PYTHON_REQUIRES='~=3.7'
+INSTALL_REQUIRES = []
+
+###################################################################
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
+
+
+META_FILE = read(META_PATH)
+
+
+def find_meta(meta):
+    """
+    Extract __*meta*__ from META_FILE.
+    """
+    meta_match = re.search(
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
+        META_FILE, re.M
+    )
+    if meta_match:
+        return meta_match.group(1)
+    raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+if __name__ == "__main__":
+    setup(
+        name=NAME,
+        description=find_meta("description"),
+        license=find_meta("license"),
+        url=find_meta("url"),
+        version=read(os.path.join("amulet_map_editor", "version")),
+        author=find_meta("author"),
+#        author_email=find_meta("email"),
+        maintainer=find_meta("author"),
+#        maintainer_email=find_meta("email"),
+        keywords=KEYWORDS,
+        long_description=read("README.md"),
+        long_description_content_type="text/markdown",
+        packages=PACKAGES,
+        zip_safe=False,
+        classifiers=CLASSIFIERS,
+        python_requires=PYTHON_REQUIRES,
+        install_requires=INSTALL_REQUIRES,
+    )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ CLASSIFIERS = [
     "Topic :: Games/Entertainment",
     "Private :: Do Not Upload",
 ]
+PACKAGE_DATA={
+    "": ["*.png", "*.mcmeta", "*.lang", "version"],
+    "amulet_map_editor.opengl": ["*.frag", "*.vert"]
+}
 PYTHON_REQUIRES='~=3.7'
 INSTALL_REQUIRES = []
 
@@ -79,6 +83,8 @@ if __name__ == "__main__":
         packages=PACKAGES,
         zip_safe=False,
         classifiers=CLASSIFIERS,
+        include_package_data=True,
+        package_data=PACKAGE_DATA,
         python_requires=PYTHON_REQUIRES,
         install_requires=INSTALL_REQUIRES,
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -81,4 +81,9 @@ if __name__ == "__main__":
         classifiers=CLASSIFIERS,
         python_requires=PYTHON_REQUIRES,
         install_requires=INSTALL_REQUIRES,
+        entry_points={
+            "gui_scripts": [
+                "amulet-map-editor = amulet_map_editor.load:run",
+            ]
+        }
     )


### PR DESCRIPTION
The main goal here is to make `pip3 install .` work properly. I need this because it makes Flatpak packaging for Linux a whole lot easier to manage. I've broken each logical change into an individual commit - each commit has pretty good explanations for why the change is needed.

The high-level summary of this patch series is:

* Misc. tweaks, some (the `__init__.py` changes) to get ready for `setup.py` and some (`chmod +x main.py`) because it's just probably a good idea
* Introduce `setup.py` so that `pip install .` works
* Make `pip install .` install a wrapper script in $PREFIX/bin to run the app, and move the code in `main.py` around to make that happen
* Add `LICENSE`, which is unrelated but I didn't feel like bothering with a whole separate PR (sorry)

Draft status because I have yet to conduct a lot of detailed testing on this PR and I need to go through the diff and add some comments to point out questions I had while preparing these patches. Also I need to run `black`.