### PR TITLE
Preserve positions and sizes of windows between program launches

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -10,6 +10,7 @@ from amulet_map_editor.api.framework.pages import WorldPageUI
 from .pages import AmuletMainMenu, BasePageUI
 
 from amulet_map_editor.api import image
+from amulet_map_editor.api.wx.util.ui_preferences import preserve_ui_preferences
 
 # Uses a conditional so if this breaks a build, we can just delete the file and it will skip the check
 try:
@@ -30,6 +31,7 @@ CLOSEABLE_PAGE_TYPE = Union[WorldPageUI]
 wx.Image.SetDefaultLoadFlags(0)
 
 
+@preserve_ui_preferences
 class AmuletUI(wx.Frame):
     def __init__(self, parent):
         wx.Frame.__init__(

--- a/amulet_map_editor/api/wx/ui/select_world.py
+++ b/amulet_map_editor/api/wx/ui/select_world.py
@@ -8,6 +8,7 @@ from amulet import world_interface
 from amulet_map_editor.api.wx.ui import simple
 from amulet_map_editor.api.logging import log
 from amulet_map_editor.api import config
+from amulet_map_editor.api.wx.util.ui_preferences import preserve_ui_preferences
 
 if TYPE_CHECKING:
     from amulet.api.wrapper import WorldFormatWrapper
@@ -286,6 +287,7 @@ class WorldSelectAndRecentUI(simple.SimplePanel):
         self._open_world_callback(path)
 
 
+@preserve_ui_preferences
 class WorldSelectDialog(wx.Dialog):
     def __init__(self, parent: wx.Window, open_world_callback: Callable[[str], None]):
         super().__init__(

--- a/amulet_map_editor/api/wx/util/ui_preferences.py
+++ b/amulet_map_editor/api/wx/util/ui_preferences.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from os.path import abspath, join, exists
+import json
+import atexit
+
+import wx
+
+PRE_EXISTING_CONFIG = {}
+
+_path = abspath(join(".", "config", 'window_preferences.config'))
+
+if exists(_path):
+    fp = open(_path)
+    PRE_EXISTING_CONFIG = json.load(fp)
+    fp.close()
+
+
+def write_config():
+    cfg_fp = open(_path, 'w+')
+    json.dump(PRE_EXISTING_CONFIG, cfg_fp)
+    cfg_fp.close()
+
+
+atexit.register(write_config)
+
+
+def on_idle(self):
+    global PRE_EXISTING_CONFIG
+
+    qualified_name = '.'.join((self.__module__, self.__class__.__name__))
+
+    def wrapper(event):
+        update_cfg = False
+        if self.__resized:
+            self.__resized = False
+            update_cfg = True
+        if self.__moved:
+            self.__moved = False
+            update_cfg = True
+        if update_cfg:
+            PRE_EXISTING_CONFIG[qualified_name] = {
+                'size': self.GetSize().Get(),
+                'position': self.GetPosition().Get()
+            }
+            self.Refresh()
+            self.Layout()
+
+    return wrapper
+
+
+def on_size(self):
+
+    def wrapper(event):
+        self.__resized = True
+
+    return wrapper
+
+
+def on_move(self):
+
+    def wrapper(event):
+        self.__moved = True
+
+    return wrapper
+
+
+def preserve_ui_preferences(clazz):
+    original_init = clazz.__init__
+    qualified_name = '.'.join((clazz.__module__, clazz.__name__))
+
+    def __init__(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.__resized = False
+        self.__moved = False
+
+        if qualified_name in PRE_EXISTING_CONFIG:
+            self.SetSize(PRE_EXISTING_CONFIG[qualified_name]['size'])
+            self.SetPosition(PRE_EXISTING_CONFIG[qualified_name]['position'])
+            self.Refresh()
+
+        self.Bind(wx.EVT_MOVE, on_move(self))
+        self.Bind(wx.EVT_SIZE, on_size(self))
+        self.Bind(wx.EVT_IDLE, on_idle(self))
+
+    clazz.__init__ = __init__
+    return clazz


### PR DESCRIPTION
This system allows for any custom window/dialog that we have created to save/restore it's position/size when initialized without requiring a full rewrite of the target class or our base UI classes.

Solution for #99 

### Changes
- For any custom UI window/dialog, adding the `@preserve_ui_preferences` decorator (from the `amulet_map_editor.api.wx.util.ui_preferences` module) to the class declaration modifies the classes `__init__` method to preserve the previous behaviour while adding the additional attributes needed and 3 new event handlers (all contained within the `ui_preferences` module)
  - No other changes are needed to the target UI class to achieve this behaviour
- All data is stored the `config/window_preferences.config` file as a JSON object once Amulet exits
  - _Note: Unexpected program exits/crashes still need testing_
- When a decorated UI class is initialized, if it's entry exists in the configuration from the same launch instance or a previous one, it will have it's position and size changed to match, otherwise it's default values will be utilized and won't be stored until changed by the user