### PR TITLE
Deselect first switches to the select tool when other tools are enabled

### DIFF
--- a/amulet_map_editor/programs/edit/canvas/controllable_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/canvas/controllable_edit_canvas.py
@@ -119,9 +119,11 @@ class ControllableEditCanvas(BaseEditCanvas):
                     if self.select_distance2 > 1:
                         self.select_distance2 -= 1
                 elif action == "deselect boxes":
-                    self._selection_group.deselect_all()
+                    if not self._deselect():
+                        self._selection_group.deselect_all()
                 elif action == "remove box":
-                    self._selection_group.deselect_active()
+                    if not self._deselect():
+                        self._selection_group.deselect_active()
                 elif action == "box click":
                     if self.selection_editable:
                         self.box_select("add box modifier" in self._persistent_actions)
@@ -215,6 +217,13 @@ class ControllableEditCanvas(BaseEditCanvas):
             for a in remove_actions:
                 if a in self._persistent_actions:
                     self._persistent_actions.remove(a)
+
+    def _deselect(self) -> bool:
+        """
+        Additional deselect logic.
+        :return: True if it has done something and further actions should be suppressed.
+        """
+        return False
 
     def box_select(self, add_modifier: bool = False):
         position = self._selection_group.box_select_toggle(add_modifier)

--- a/amulet_map_editor/programs/edit/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/canvas/edit_canvas.py
@@ -142,6 +142,9 @@ class EditCanvas(ControllableEditCanvas):
     def tools(self):
         return self._tool_sizer.tools
 
+    def _deselect(self) -> bool:
+        return self._tool_sizer.enable_default_tool()
+
     def run_operation(
         self,
         operation: Callable[[], OperationReturnType],

--- a/amulet_map_editor/programs/edit/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/canvas/edit_canvas.py
@@ -16,7 +16,7 @@ from amulet_map_editor.programs.edit.key_config import (
     PresetKeybinds,
 )
 from amulet_map_editor.programs.edit.canvas.ui.goto import show_goto
-from amulet_map_editor.programs.edit.canvas.ui.tool import Tool
+from amulet_map_editor.programs.edit.canvas.ui.tool import ToolManagerSizer
 from amulet_map_editor.programs.edit.plugins import (
     OperationError,
     OperationSuccessful,
@@ -99,7 +99,7 @@ class EditCanvas(ControllableEditCanvas):
         super().__init__(parent, world, **kwargs)
         self._close_callback = close_callback
         self._file_panel: Optional[FilePanel] = None
-        self._tool_sizer: Optional[Tool] = None
+        self._tool_sizer: Optional[ToolManagerSizer] = None
         config_ = config.get(EDIT_CONFIG_ID, {})
         user_keybinds = config_.get("user_keybinds", {})
         group = config_.get("keybind_group", DefaultKeybindGroupId)
@@ -122,7 +122,7 @@ class EditCanvas(ControllableEditCanvas):
         file_sizer.Add(self._file_panel, 0, wx.EXPAND, 0)
         canvas_sizer.Add(file_sizer, 0, wx.EXPAND, 0)
 
-        self._tool_sizer = Tool(self)
+        self._tool_sizer = ToolManagerSizer(self)
         canvas_sizer.Add(self._tool_sizer, 1, wx.EXPAND, 0)
         self._bind_events()
 

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/__init__.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/__init__.py
@@ -1,1 +1,1 @@
-from .tool import Tool
+from .tool import ToolManagerSizer

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tool.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tool.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ...edit_canvas import EditCanvas
 
 
-class Tool(wx.BoxSizer, BaseUI):
+class ToolManagerSizer(wx.BoxSizer, BaseUI):
     def __init__(self, canvas: "EditCanvas"):
         wx.BoxSizer.__init__(self, wx.VERTICAL)
         BaseUI.__init__(self, canvas)
@@ -38,11 +38,11 @@ class Tool(wx.BoxSizer, BaseUI):
         tool_select_sizer.AddStretchSpacer(1)
         self.Add(tool_select_sizer, 0, wx.EXPAND, 0)
 
-        self.register_tool("Select", SelectOptions)
+        self.register_tool(SelectOptions)
         self._enable_tool("Select")
-        self.register_tool("Operation", SelectOperationUI)
-        self.register_tool("Import", SelectImportOperationUI)
-        self.register_tool("Export", SelectExportOperationUI)
+        self.register_tool(SelectOperationUI)
+        self.register_tool(SelectImportOperationUI)
+        self.register_tool(SelectExportOperationUI)
 
     @property
     def tools(self):
@@ -53,17 +53,17 @@ class Tool(wx.BoxSizer, BaseUI):
             tool.bind_events()
         self.canvas.Bind(EVT_TOOL_CHANGE, self._enable_tool_event)
 
-    def register_tool(self, name: str, tool_cls: Type[BaseToolUIType]):
+    def register_tool(self, tool_cls: Type[BaseToolUIType]):
         assert issubclass(tool_cls, (wx.Window, wx.Sizer)) and issubclass(
             tool_cls, BaseToolUI
         )
-        self._tool_select.register_tool(name)
         tool = tool_cls(self.canvas)
+        self._tool_select.register_tool(tool.name)
         if isinstance(tool, wx.Window):
             tool.Hide()
         elif isinstance(tool, wx.Sizer):
             tool.ShowItems(show=False)
-        self._tools[name] = tool
+        self._tools[tool.name] = tool
         self._tool_option_sizer.Add(tool, 1, wx.EXPAND, 0)
 
     def _enable_tool_event(self, evt):

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tool.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tool.py
@@ -70,6 +70,16 @@ class ToolManagerSizer(wx.BoxSizer, BaseUI):
         self._enable_tool(evt.tool)
         evt.Skip()
 
+    def enable_default_tool(self) -> bool:
+        """
+        Enables the default tool (the select tool)
+        :return: True if the selection changed, False otherwise.
+        """
+        if not isinstance(self._active_tool, SelectOptions):
+            self._enable_tool("Select")
+            return True
+        return False
+
     def _enable_tool(self, tool: str):
         if tool in self._tools:
             if self._active_tool is not None:

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/base_operation.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/base_operation.py
@@ -47,6 +47,10 @@ class BaseSelectOperationUI(wx.BoxSizer, BaseToolUI):
 
         # self._operation_change()
 
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
     def bind_events(self):
         pass
 

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/base_tool_ui.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/base_tool_ui.py
@@ -6,6 +6,10 @@ BaseToolUIType = Union[wx.Window, wx.Sizer, "BaseToolUI"]
 
 
 class BaseToolUI(BaseUI):
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
     def enable(self):
         pass
 

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/export_tool.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/export_tool.py
@@ -4,5 +4,9 @@ from amulet_map_editor.programs.edit import plugins
 
 class SelectExportOperationUI(BaseSelectOperationUI):
     @property
+    def name(self) -> str:
+        return "Export"
+
+    @property
     def _operations(self) -> plugins.OperationStorageType:
         return plugins.export_operations

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/import_tool.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/import_tool.py
@@ -4,5 +4,9 @@ from amulet_map_editor.programs.edit import plugins
 
 class SelectImportOperationUI(BaseSelectOperationUI):
     @property
+    def name(self) -> str:
+        return "Import"
+
+    @property
     def _operations(self) -> plugins.OperationStorageType:
         return plugins.import_operations

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/operation.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/operation.py
@@ -4,5 +4,9 @@ from amulet_map_editor.programs.edit import plugins
 
 class SelectOperationUI(BaseSelectOperationUI):
     @property
+    def name(self) -> str:
+        return "Operation"
+
+    @property
     def _operations(self) -> plugins.OperationStorageType:
         return plugins.operations

--- a/amulet_map_editor/programs/edit/canvas/ui/tool/tools/select.py
+++ b/amulet_map_editor/programs/edit/canvas/ui/tool/tools/select.py
@@ -87,6 +87,10 @@ class SelectOptions(wx.BoxSizer, BaseToolUI):
         self._y2.SetBackgroundColour((150, 150, 215))
         self._z2.SetBackgroundColour((150, 150, 215))
 
+    @property
+    def name(self) -> str:
+        return "Select"
+
     def bind_events(self):
         self.canvas.Bind(EVT_PASTE, self._paste)
         self._canvas().Bind(EVT_BOX_CHANGE, self._box_renderer_change)


### PR DESCRIPTION
If any other tool is enabled (eg the operation tool) and the deselect action is run it will switch to the select tool.
Once in the select tool the command will deselect the actual box.
This is essentially just a shortcut to get to the select tool.