### PR TITLE
Fixed an issue with the wrapper blocking events

### DIFF
--- a/amulet_map_editor/api/wx/util/ui_preferences.py
+++ b/amulet_map_editor/api/wx/util/ui_preferences.py
@@ -21,7 +21,7 @@ def on_idle(self):
 
     qualified_name = ".".join((self.__module__, self.__class__.__name__))
 
-    def wrapper(_):
+    def wrapper(evt):
         update_cfg = False
         if self.__resized:
             self.__resized = False
@@ -36,20 +36,23 @@ def on_idle(self):
             }
             self.Refresh()
             self.Layout()
+        evt.Skip()
 
     return wrapper
 
 
 def on_size(self):
-    def wrapper(_):
+    def wrapper(evt):
         self.__resized = True
+        evt.Skip()
 
     return wrapper
 
 
 def on_move(self):
-    def wrapper(_):
+    def wrapper(evt):
         self.__moved = True
+        evt.Skip()
 
     return wrapper
 


### PR DESCRIPTION
The wrapper was blocking the resize event which meant that contained objects were only resizing when the mouse was released.