### PR TITLE
Added auto-updater

### DIFF
--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -106,7 +106,9 @@ class CheckForUpdate(threading.Thread):
                         break
 
             if self._new_version:
-                evt = UpdateEvent(_EVT_UPDATE_CHECK, -1, self._new_version, current_version[0])
+                evt = UpdateEvent(
+                    _EVT_UPDATE_CHECK, -1, self._new_version, current_version[0]
+                )
                 wx.PostEvent(self._parent, evt)
         except Exception:
             pass
@@ -153,7 +155,10 @@ class UpdateDialog(wx.Dialog):
         )
         if not __debug__:
             updater_button.Bind(
-                wx.EVT_BUTTON, lambda evt: self.auto_update(current_version, new_version, is_beta, evt)
+                wx.EVT_BUTTON,
+                lambda evt: self.auto_update(
+                    current_version, new_version, is_beta, evt
+                ),
             )
         ok_button.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
 
@@ -178,31 +183,27 @@ class UpdateDialog(wx.Dialog):
         with zipfile.ZipFile(updater_zip, "r") as z:
             z.extractall(temp_dir)
 
-        jars = glob.glob(os.path.join(temp_dir, '*.jar'))
+        jars = glob.glob(os.path.join(temp_dir, "*.jar"))
         updater_jar = jars[0]
         log.info(f"Using AmuletUpdater jar: {updater_jar}")
         args = [
-                os.path.join(temp_dir, "openjdk-14.0.2", "bin", "java.exe"),
-                "-jar",
-                updater_jar,
-                "-current_version",
-                current_version,
-                "-target_version",
-                target_version,
-                "-wd",
-                working_directory,
-                "-pid",
-                str(os.getpid()),
-            ]
+            os.path.join(temp_dir, "openjdk-14.0.2", "bin", "java.exe"),
+            "-jar",
+            updater_jar,
+            "-current_version",
+            current_version,
+            "-target_version",
+            target_version,
+            "-wd",
+            working_directory,
+            "-pid",
+            str(os.getpid()),
+        ]
 
         if is_beta:
-            args.append('-install_beta')
+            args.append("-install_beta")
 
-        p = subprocess.Popen(
-            args,
-            shell=True,
-            cwd=temp_dir,
-        )
+        p = subprocess.Popen(args, shell=True, cwd=temp_dir)
 
 
 def show_update_window(parent, current_version: str, evt: UpdateEvent):

--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -19,7 +19,7 @@ from amulet_map_editor.api.logging import log
 
 URL = "http://api.github.com/repos/Amulet-Team/Amulet-Map-Editor/releases"
 
-UPDATER_DOWNLOAD_URL = "https://github.com/Podshot/AmuletUpdater/releases/download/latest/AmuletUpdater.zip"
+UPDATER_DOWNLOAD_URL = "https://github.com/Amulet-Team/AmuletUpdater/releases/download/latest/AmuletUpdater.zip"
 JAVA_DOWNLOAD_URL = "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
 
 NOT_RUNNING_FROM_SOURCE = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")

--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -22,7 +22,7 @@ URL = "http://api.github.com/repos/Amulet-Team/Amulet-Map-Editor/releases"
 LATEST_UPDATER_RELEASE_URL = (
     "https://api.github.com/repos/Amulet-Team/AmuletUpdater/releases/latest"
 )
-JAVA_DOWNLOAD_URL = "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
+JAVA_DOWNLOAD_URL = "https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.zip"
 
 NOT_RUNNING_FROM_SOURCE = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 AUTOUPDATER_SUPPORTED_OS = platform.system() in ("Windows",)
@@ -231,7 +231,7 @@ class UpdateDialog(wx.Dialog):
         updater_jar = jars[0]
         log.info(f"Using AmuletUpdater jar: {updater_jar}")
         args = [
-            os.path.join(temp_dir, "jdk-14.0.2", "bin", "java.exe"),
+            os.path.join(temp_dir, "jdk-14.0.2+12-jre", "bin", "java.exe"),
             "-jar",
             updater_jar,
             "-current_version",


### PR DESCRIPTION
This adds an external auto-updater that can be used when the user is notified that a new update has been released. Currently the updater only has support for Windows installations and has only been tested on Windows. The updater will download the latest update, backup the current installation, copy over plugins/operations/settings, then restart Amulet.

- [Amulet Updater codebase](https://github.com/Podshot/AmuletUpdater)
  - The updater is written in Java and the release comes with a bundled OpenJDK distribution
- [Update operation](https://gist.github.com/Podshot/f415300561d43d203158ce786d95e0a3)
  - An testing operation that allows for others to test of the update process on an already built past release, this is not included in this pull request