### PR TITLE
Fixed the renderer appearing upside down

### DIFF
--- a/amulet_map_editor/api/opengl/camera/camera.py
+++ b/amulet_map_editor/api/opengl/camera/camera.py
@@ -180,17 +180,42 @@ class Camera(CanvasContainer):
         self.set_rotation(rotation)
         self._notify_moved()
 
+    def _set_fov(self, mode: Projection, fov: float):
+        assert type(fov) in (int, float)
+        self._fov[mode.value] = fov
+        self._reset_matrix()
+
     @property
     def fov(self) -> float:
-        """The field of view of the camera in degrees."""
+        """The field of view of the camera.
+        The value will vary based on the projection mode."""
         return self._fov[self.projection_mode.value]
 
     @fov.setter
     def fov(self, fov: float):
-        """Set the field of view of the camera in degrees."""
-        assert type(fov) in (int, float)
-        self._fov[self.projection_mode.value] = fov
-        self._reset_matrix()
+        """Set the field of view of the camera.
+        The value will vary based on the projection mode."""
+        self._set_fov(self.projection_mode, fov)
+
+    @property
+    def perspective_fov(self) -> float:
+        """The field of view of the camera in degrees when in perspective mode."""
+        return self._fov[Projection.PERSPECTIVE.value]
+
+    @perspective_fov.setter
+    def perspective_fov(self, fov: float):
+        """Set the field of view of the camera in degrees when in perspective mode."""
+        self._set_fov(Projection.PERSPECTIVE, fov)
+
+    @property
+    def orthographic_fov(self) -> float:
+        """The field of view of the camera when in orthographic mode."""
+        return self._fov[Projection.TOP_DOWN.value]
+
+    @orthographic_fov.setter
+    def orthographic_fov(self, fov: float):
+        """Set the field of view of the camera when in orthographic mode."""
+        self._set_fov(Projection.TOP_DOWN, fov)
 
     @property
     def aspect_ratio(self) -> float:

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -63,7 +63,9 @@ class EditExtension(wx.Panel, BaseProgram):
                 wx.Yield()
 
             edit_config: dict = config.get(EDIT_CONFIG_ID, {})
-            self._canvas.camera.perspective_fov = edit_config.get("options", {}).get("fov", 70.0)
+            self._canvas.camera.perspective_fov = edit_config.get("options", {}).get(
+                "fov", 70.0
+            )
             if self._canvas.camera.perspective_fov > 180:
                 self._canvas.camera.perspective_fov = 70.0
             self._canvas.renderer.render_distance = edit_config.get("options", {}).get(

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -63,7 +63,9 @@ class EditExtension(wx.Panel, BaseProgram):
                 wx.Yield()
 
             edit_config: dict = config.get(EDIT_CONFIG_ID, {})
-            self._canvas.camera.fov = edit_config.get("options", {}).get("fov", 70.0)
+            self._canvas.camera.perspective_fov = edit_config.get("options", {}).get("fov", 70.0)
+            if self._canvas.camera.perspective_fov > 180:
+                self._canvas.camera.perspective_fov = 70.0
             self._canvas.renderer.render_distance = edit_config.get("options", {}).get(
                 "render_distance", 5
             )
@@ -194,7 +196,7 @@ class EditExtension(wx.Panel, BaseProgram):
 
     def _edit_options(self):
         if self._canvas is not None:
-            fov = self._canvas.camera.fov
+            fov = self._canvas.camera.perspective_fov
             render_distance = self._canvas.renderer.render_distance
             camera_sensitivity = self._canvas.camera.rotate_speed
             dialog = SimpleDialog(self, "Options")
@@ -204,7 +206,7 @@ class EditExtension(wx.Panel, BaseProgram):
             fov_ui = wx.SpinCtrlDouble(dialog, min=0, max=180, initial=fov)
 
             def set_fov(evt):
-                self._canvas.camera.fov = fov_ui.GetValue()
+                self._canvas.camera.perspective_fov = fov_ui.GetValue()
 
             fov_ui.Bind(wx.EVT_SPINCTRLDOUBLE, set_fov)
             sizer.Add(
@@ -271,7 +273,7 @@ class EditExtension(wx.Panel, BaseProgram):
                 ] = camera_sensitivity_ui.GetValue()
                 config.put(EDIT_CONFIG_ID, edit_config)
             elif response == wx.ID_CANCEL:
-                self._canvas.camera.fov = fov
+                self._canvas.camera.perspective_fov = fov
                 self._canvas.renderer.render_distance = render_distance
                 self._canvas.camera.rotate_speed = camera_sensitivity
 


### PR DESCRIPTION
There was a case where the fov could be set to greater than 180 which would flip the renderer upside down.
This should fix that.
This was caused by the fov in perspective and orthographic mode sharing the same attribute. This adds in attributes for each of them.