### PR TITLE
Disable timers on window destroy

### DIFF
--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -124,11 +124,18 @@ class ButtonInput(WindowContainer):
             wx.EVT_TIMER, self._process_continuous_inputs, self._input_timer
         )
 
+        # save destruction
+        self.window.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
+
     def enable(self):
         self._input_timer.Start(33)
 
     def disable(self):
         self._input_timer.Stop()
+
+    def _on_destroy(self, evt):
+        self.disable()
+        evt.Skip()
 
     @property
     def pressed_keys(self) -> Set[KeyType]:

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -90,6 +90,7 @@ class Renderer(EditCanvasContainer):
             self._draw_timer,
         )
         self.canvas.Bind(EVT_CAMERA_MOVED, self._on_camera_moved)
+        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
 
     def enable(self):
         """Enable and start working."""
@@ -100,6 +101,10 @@ class Renderer(EditCanvasContainer):
         self.disable_threads()
         self.render_world.unload()
         self.fake_levels.unload()
+
+    def _on_destroy(self, evt):
+        self.disable()
+        evt.Skip()
 
     def is_closeable(self):
         """Check that the data is safe to be closed."""

--- a/amulet_map_editor/programs/edit/api/selection.py
+++ b/amulet_map_editor/programs/edit/api/selection.py
@@ -43,6 +43,7 @@ class SelectionManager(Changeable):
     def bind_events(self):
         """Set up all events required to run."""
         self.canvas.Bind(wx.EVT_TIMER, self._create_undo_point, self._timer)
+        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
 
     def _create_undo_point(self, evt):
         self.canvas.create_undo_point(False, True)
@@ -52,6 +53,10 @@ class SelectionManager(Changeable):
         """Start a timer to create an undo point after a period of time.
         If this is called again before the timer runs then the last call will not happen."""
         self._timer.StartOnce(400)
+
+    def _on_destroy(self, evt):
+        self._timer.Stop()
+        evt.Skip()
 
     @property
     def selection_corners(


### PR DESCRIPTION
There were some issues where the program would crash due to timer accessing windows that no longer existed. This will disable the timers when the window is destroyed to make sure that does not happen