### PR TITLE
Upgrade paste tool

### DIFF
--- a/amulet_map_editor/api/opengl/camera/camera.py
+++ b/amulet_map_editor/api/opengl/camera/camera.py
@@ -71,6 +71,9 @@ class ProjectionChangedEvent(wx.PyEvent):
 class Camera(CanvasContainer):
     """A class to hold the state information of the camera."""
 
+    _projection_matrix: Optional[TransformationMatrixType]
+    _transformation_matrix: Optional[TransformationMatrixType]
+
     __slots__ = (
         "_location",
         "_rotation",
@@ -304,6 +307,7 @@ class Camera(CanvasContainer):
                 self._projection_matrix = self.orthographic_matrix
             else:
                 self._projection_matrix = self.perspective_matrix
+            self._projection_matrix.flags.writeable = False
 
         return self._projection_matrix
 
@@ -330,5 +334,6 @@ class Camera(CanvasContainer):
                 self.projection_matrix,
                 self.camera_matrix,
             )
+            self._transformation_matrix.flags.writeable = False
 
         return self._transformation_matrix

--- a/amulet_map_editor/api/opengl/camera/camera.py
+++ b/amulet_map_editor/api/opengl/camera/camera.py
@@ -161,12 +161,22 @@ class Camera(CanvasContainer):
             self._notify_moved()
 
     def set_rotation(self, camera_rotation: CameraRotationType) -> bool:
-        """Set the location of the camera. (x, y, z)."""
+        """Set the rotation of the camera. (yaw, pitch).
+        yaw (-180 to 180), pitch (-90 to 90)
+        This should behave the same as how Minecraft handles it."""
         assert (
             type(camera_rotation) in (tuple, list)
             and len(camera_rotation) == 2
             and all(type(v) in (int, float) for v in camera_rotation)
         ), "format for camera_rotation is invalid"
+        ry, rx = camera_rotation
+        if not -180 <= ry < 180:
+            ry %= 360
+            if ry >= 180:
+                ry -= 360
+        if not -90 <= rx <= 90:
+            rx = max(min(rx, 90), -90)
+        camera_rotation = (ry, rx)
         if camera_rotation != self._rotation:
             self._reset_matrix()
             self._rotation = tuple(camera_rotation)

--- a/amulet_map_editor/api/opengl/mesh/level_group.py
+++ b/amulet_map_editor/api/opengl/mesh/level_group.py
@@ -97,9 +97,12 @@ class LevelGroup(
 
     def _set_camera_location(self):
         for level, transform in zip(self._objects, self._transformation_matrices):
-            level.camera_location = numpy.matmul(
-                numpy.linalg.inv(transform), (*self._camera_location, 1)
-            ).tolist()[:-1]
+            try:
+                level.camera_location = numpy.matmul(
+                    numpy.linalg.inv(transform), (*self._camera_location, 1)
+                ).tolist()[:-1]
+            except numpy.linalg.LinAlgError:
+                pass
 
     def set_camera_rotation(self, yaw: float, pitch: float):
         """Set the rotation of the camera for each of the levels."""

--- a/amulet_map_editor/api/opengl/mesh/level_group.py
+++ b/amulet_map_editor/api/opengl/mesh/level_group.py
@@ -1,5 +1,13 @@
 from typing import List, Optional, Tuple, Any
 import numpy
+from OpenGL.GL import (
+    glCullFace,
+    GL_FRONT,
+    GL_BACK,
+    glPushAttrib,
+    GL_POLYGON_BIT,
+    glPopAttrib,
+)
 
 from amulet.api.level import BaseLevel
 from amulet.api.data_types import FloatTriplet, PointCoordinates, Dimension
@@ -42,6 +50,7 @@ class LevelGroup(
         self._transforms: List[TransformType] = []
         self._world_translation: List[LocationType] = []
         self._transformation_matrices: List[numpy.ndarray] = []
+        self._front_face: List[bool] = []
         self._active_level_index: Optional[int] = None
         self._camera_location: LocationType = (0.0, 100.0, 0.0)
 
@@ -72,6 +81,9 @@ class LevelGroup(
         if self._active_level_index is not None:
             location, scale, rotation = location_scale_rotation
             self._transforms[self._active_level_index] = (location, scale, rotation)
+            self._front_face[self._active_level_index] = bool(
+                sum(1 for s in scale if s < 0) % 2
+            )
             self._transformation_matrices[self._active_level_index] = numpy.matmul(
                 transform_matrix(scale, rotation, location),
                 displacement_matrix(*self._world_translation[self._active_level_index]),
@@ -117,6 +129,7 @@ class LevelGroup(
         self.register(render_level)
         # the transforms (tuple) applied by the user
         self._transforms.append((location, scale, rotation))
+        self._front_face.append(bool(sum(1 for s in scale if s < 0) % 2))
         self._world_translation.append(
             (
                 -(
@@ -152,6 +165,7 @@ class LevelGroup(
         for level in self._objects.copy():
             self.unregister(level)
         self._transforms.clear()
+        self._front_face.clear()
         self._world_translation.clear()
         self._transformation_matrices.clear()
         self._active_level_index = None
@@ -171,5 +185,13 @@ class LevelGroup(
 
     def draw(self, camera_matrix: numpy.ndarray):
         """Draw all of the levels."""
-        for level, transform in zip(self._objects, self._transformation_matrices):
+        for level, transform, front_face in zip(
+            self._objects, self._transformation_matrices, self._front_face
+        ):
+            glPushAttrib(GL_POLYGON_BIT)  # store opengl state
+            if front_face:
+                glCullFace(GL_FRONT)
+            else:
+                glCullFace(GL_BACK)
             level.draw(numpy.matmul(camera_matrix, transform))
+            glPopAttrib()  # reset to starting state

--- a/amulet_map_editor/api/opengl/mesh/level_group.py
+++ b/amulet_map_editor/api/opengl/mesh/level_group.py
@@ -50,7 +50,7 @@ class LevelGroup(
         self._transforms: List[TransformType] = []
         self._world_translation: List[LocationType] = []
         self._transformation_matrices: List[numpy.ndarray] = []
-        self._front_face: List[bool] = []
+        self._is_mirrored: List[bool] = []
         self._active_level_index: Optional[int] = None
         self._camera_location: LocationType = (0.0, 100.0, 0.0)
 
@@ -81,7 +81,7 @@ class LevelGroup(
         if self._active_level_index is not None:
             location, scale, rotation = location_scale_rotation
             self._transforms[self._active_level_index] = (location, scale, rotation)
-            self._front_face[self._active_level_index] = bool(
+            self._is_mirrored[self._active_level_index] = bool(
                 sum(1 for s in scale if s < 0) % 2
             )
             self._transformation_matrices[self._active_level_index] = numpy.matmul(
@@ -132,7 +132,7 @@ class LevelGroup(
         self.register(render_level)
         # the transforms (tuple) applied by the user
         self._transforms.append((location, scale, rotation))
-        self._front_face.append(bool(sum(1 for s in scale if s < 0) % 2))
+        self._is_mirrored.append(bool(sum(1 for s in scale if s < 0) % 2))
         self._world_translation.append(
             (
                 -(
@@ -168,7 +168,7 @@ class LevelGroup(
         for level in self._objects.copy():
             self.unregister(level)
         self._transforms.clear()
-        self._front_face.clear()
+        self._is_mirrored.clear()
         self._world_translation.clear()
         self._transformation_matrices.clear()
         self._active_level_index = None
@@ -188,11 +188,11 @@ class LevelGroup(
 
     def draw(self, camera_matrix: numpy.ndarray):
         """Draw all of the levels."""
-        for level, transform, front_face in zip(
-            self._objects, self._transformation_matrices, self._front_face
+        for level, transform, is_mirrored in zip(
+            self._objects, self._transformation_matrices, self._is_mirrored
         ):
             glPushAttrib(GL_POLYGON_BIT)  # store opengl state
-            if front_face:
+            if is_mirrored:
                 glCullFace(GL_FRONT)
             else:
                 glCullFace(GL_BACK)

--- a/amulet_map_editor/api/opengl/mesh/selection/box/render_selection.py
+++ b/amulet_map_editor/api/opengl/mesh/selection/box/render_selection.py
@@ -13,6 +13,8 @@ from OpenGL.GL import (
     GL_POLYGON_BIT,
     glPopAttrib,
     GL_ENABLE_BIT,
+    glGetIntegerv,
+    GL_CULL_FACE_MODE,
 )
 import itertools
 from typing import Tuple, Optional, Union
@@ -326,9 +328,11 @@ class RenderSelection(TriMesh, OpenGLResourcePackManagerStatic):
         )  # store opengl state
 
         if camera_position is not None and camera_position in self:
-            glCullFace(GL_FRONT)
-        else:
-            glCullFace(GL_BACK)
+            mode = glGetIntegerv(GL_CULL_FACE_MODE)
+            if mode == GL_BACK:
+                glCullFace(GL_FRONT)
+            elif mode == GL_FRONT:
+                glCullFace(GL_BACK)
 
         self.draw_start = 0
         self.draw_count = 36

--- a/amulet_map_editor/api/opengl/mesh/selection/box/render_selection.py
+++ b/amulet_map_editor/api/opengl/mesh/selection/box/render_selection.py
@@ -12,6 +12,7 @@ from OpenGL.GL import (
     GL_DEPTH_BUFFER_BIT,
     GL_POLYGON_BIT,
     glPopAttrib,
+    GL_ENABLE_BIT,
 )
 import itertools
 from typing import Tuple, Optional, Union
@@ -320,7 +321,9 @@ class RenderSelection(TriMesh, OpenGLResourcePackManagerStatic):
 
         transformation_matrix = numpy.matmul(camera_matrix, self.transformation_matrix)
 
-        glPushAttrib(GL_DEPTH_BUFFER_BIT | GL_POLYGON_BIT)  # store opengl state
+        glPushAttrib(
+            GL_DEPTH_BUFFER_BIT | GL_POLYGON_BIT | GL_ENABLE_BIT
+        )  # store opengl state
 
         if camera_position is not None and camera_position in self:
             glCullFace(GL_FRONT)

--- a/amulet_map_editor/api/opengl/mesh/selection/box/render_selection_editable.py
+++ b/amulet_map_editor/api/opengl/mesh/selection/box/render_selection_editable.py
@@ -290,10 +290,11 @@ class RenderSelectionEditable(RenderSelectionHighlightable):
         self._draw_mode = GL_LINE_STRIP
         super()._draw(transformation_matrix)
 
-        if camera_position is not None and camera_position in self:
-            glCullFace(GL_FRONT)
-        else:
-            glCullFace(GL_BACK)
+        if camera_position is not None:
+            if camera_position in self:
+                glCullFace(GL_FRONT)
+            else:
+                glCullFace(GL_BACK)
 
         glEnable(GL_DEPTH_TEST)
         self._draw_mode = GL_TRIANGLES

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -92,6 +92,7 @@ program_3d_edit.paste_tool.copy_lava_label=Copy Lava
 program_3d_edit.paste_tool.copy_lava_tooltip=If enabled all lava blocks in the pasted structure will be applied overwriting any existing blocks. If disabled the existing blocks at those locations will remain and lava will not be copied.
 program_3d_edit.paste_tool.confirm_label=Confirm
 program_3d_edit.paste_tool.confirm_tooltip=Click to paste the structure into the world and the specified location, rotation and scale.
+program_3d_edit.paste_tool.zero_scale_message=One of the scale values had a value of zero so nothing was copied.
 
 program_3d_edit.chunk_tool.min_y=Min Y
 program_3d_edit.chunk_tool.min_y_tooltip=The minimum y coordinate to draw in the top down view. This can be used to view a slice of the world and help view dimensions like the nether and caves.

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -34,7 +34,6 @@ program_3d_edit.select_tool.cut_button=Cut
 program_3d_edit.select_tool.cut_button_tooltip=Copy the selected area to paste later and delete. Can be pasted into any world and dimension.
 program_3d_edit.select_tool.paste_button=Paste
 program_3d_edit.select_tool.paste_button_tooltip=Paste a previously copied or cut area into the world.
-
 program_3d_edit.select_tool.scroll_point_x1=x1
 program_3d_edit.select_tool.scroll_point_y1=y1
 program_3d_edit.select_tool.scroll_point_z1=z1
@@ -47,16 +46,52 @@ program_3d_edit.select_tool.scroll_point_z1_tooltip=Set the z coordinate of the 
 program_3d_edit.select_tool.scroll_point_x2_tooltip=Set the x coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
 program_3d_edit.select_tool.scroll_point_y2_tooltip=Set the y coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
 program_3d_edit.select_tool.scroll_point_z2_tooltip=Set the z coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
-
 program_3d_edit.select_tool.box_size_fstring=dx={x},dy={y},dz={z}
 program_3d_edit.select_tool.box_size_tooltip=The size of the active selection box in blocks.
-
 program_3d_edit.select_tool.button_point1=Move Point 1
 program_3d_edit.select_tool.button_point1_tooltip=Press and hold this button and use the movement controls to move the green selection point.
 program_3d_edit.select_tool.button_point2=Move Point 2
 program_3d_edit.select_tool.button_point2_tooltip=Press and hold this button and use the movement controls to move the blue selection point.
 program_3d_edit.select_tool.button_selection_box=Move Box
 program_3d_edit.select_tool.button_selection_box_tooltip=Press and hold this button and use the movement controls to move the active box.
+
+program_3d_edit.paste_tool.location_label=Location
+program_3d_edit.paste_tool.location_x_label=x
+program_3d_edit.paste_tool.location_x_tooltip=The x location where the centre of the selection will be placed. Type in a number, scroll wheel over or use the arrows to change.
+program_3d_edit.paste_tool.location_y_label=y
+program_3d_edit.paste_tool.location_y_tooltip=The y location where the centre of the selection will be placed. Type in a number, scroll wheel over or use the arrows to change.
+program_3d_edit.paste_tool.location_z_label=z
+program_3d_edit.paste_tool.location_z_tooltip=The z location where the centre of the selection will be placed. Type in a number, scroll wheel over or use the arrows to change.
+program_3d_edit.paste_tool.move_selection_label=Move Selection
+program_3d_edit.paste_tool.move_selection_tooltip=Press and hold this button and use the movement controls to move the selection.
+program_3d_edit.paste_tool.rotation_label=Rotation
+program_3d_edit.paste_tool.free_rotation_label=Free Rotation
+program_3d_edit.paste_tool.free_rotation_tooltip=If unticked the selection can be rotated in multiples of 90 degrees. If ticked the selection can be rotated in single degree increments.
+program_3d_edit.paste_tool.rotation_x_label=x
+program_3d_edit.paste_tool.rotation_x_tooltip=The angle in degrees in the x axis that the selection is rotated in. Note this is the model's x axis which is transformed by the z and y rotation so this may not match the global x axis.
+program_3d_edit.paste_tool.rotation_y_label=y
+program_3d_edit.paste_tool.rotation_y_tooltip=The angle in degrees in the y axis that the selection is rotated in. Note this is the model's y axis which is transformed by the z rotation so this may not match the global y axis.
+program_3d_edit.paste_tool.rotation_z_label=z
+program_3d_edit.paste_tool.rotation_z_tooltip=The angle in degrees in the z axis that the selection is rotated in.
+program_3d_edit.paste_tool.rotate_anti_clockwise_tooltip=Click to rotate the selection 90 degrees anti-clockwise relative to the look rotation.
+program_3d_edit.paste_tool.rotate_clockwise_tooltip=Click to rotate the selection 90 degrees clockwise relative to the look rotation.
+program_3d_edit.paste_tool.scale_label=Scale
+program_3d_edit.paste_tool.scale_x_label=x
+program_3d_edit.paste_tool.scale_x_tooltip=The scale of the model in the x axis.
+program_3d_edit.paste_tool.scale_y_label=y
+program_3d_edit.paste_tool.scale_y_tooltip=The scale of the model in the y axis.
+program_3d_edit.paste_tool.scale_z_label=z
+program_3d_edit.paste_tool.scale_z_tooltip=The scale of the model in the z axis.
+program_3d_edit.paste_tool.mirror_horizontal_tooltip=Mirror the selection horizontally relative to the direction the camera is looking.
+program_3d_edit.paste_tool.mirror_vertical_tooltip=Mirror the selection vertically relative to the direction the camera is looking.
+program_3d_edit.paste_tool.copy_air_label=Copy Air
+program_3d_edit.paste_tool.copy_air_tooltip=If enabled all air blocks in the pasted structure will be applied overwriting any existing blocks. If disabled the existing blocks at those locations will remain and air will not be copied.
+program_3d_edit.paste_tool.copy_water_label=Copy Water
+program_3d_edit.paste_tool.copy_water_tooltip=If enabled all water blocks in the pasted structure will be applied overwriting any existing blocks. If disabled the existing blocks at those locations will remain and water will not be copied.
+program_3d_edit.paste_tool.copy_lava_label=Copy Lava
+program_3d_edit.paste_tool.copy_lava_tooltip=If enabled all lava blocks in the pasted structure will be applied overwriting any existing blocks. If disabled the existing blocks at those locations will remain and lava will not be copied.
+program_3d_edit.paste_tool.confirm_label=Confirm
+program_3d_edit.paste_tool.confirm_tooltip=Click to paste the structure into the world and the specified location, rotation and scale.
 
 program_3d_edit.chunk_tool.min_y=Min Y
 program_3d_edit.chunk_tool.min_y_tooltip=The minimum y coordinate to draw in the top down view. This can be used to view a slice of the world and help view dimensions like the nether and caves.

--- a/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
@@ -157,11 +157,7 @@ class CameraBehaviour(BaseBehaviour):
                 - math.sin(math.radians(ry)) * right
             )
             rx += self.canvas.camera.rotate_speed * pitch
-            if not -90 <= rx <= 90:
-                rx = max(min(rx, 90), -90)
             ry += self.canvas.camera.rotate_speed * yaw
-            if not -180 <= ry <= 180:
-                ry += -int(numpy.sign(ry)) * 360
         else:
             ry, rx = 180, 90
             x += right

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -376,6 +376,9 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._scale.x.SetToolTip(lang.get("program_3d_edit.paste_tool.scale_x_tooltip"))
         self._scale.y.SetToolTip(lang.get("program_3d_edit.paste_tool.scale_y_tooltip"))
         self._scale.z.SetToolTip(lang.get("program_3d_edit.paste_tool.scale_z_tooltip"))
+        self._scale.x.SetDigits(2)
+        self._scale.y.SetDigits(2)
+        self._scale.z.SetDigits(2)
         self._paste_sizer.Add(
             self._scale,
             flag=BottomLeftRightExpand,

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -1,9 +1,10 @@
 import wx
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union, Type
 from OpenGL.GL import (
     glClear,
     GL_DEPTH_BUFFER_BIT,
 )
+import math
 
 from amulet.operations.paste import paste_iter
 
@@ -13,9 +14,7 @@ from amulet_map_editor.api.opengl.mesh.level import RenderLevel
 from amulet_map_editor.programs.edit.api.ui.tool import DefaultBaseToolUI
 from amulet_map_editor.programs.edit.api.events import EVT_PASTE
 from amulet_map_editor.programs.edit.api.ui.select_location import (
-    SelectTransformUI,
     TransformChangeEvent,
-    EVT_TRANSFORM_CHANGE,
 )
 
 from amulet_map_editor.programs.edit.api.behaviour import StaticSelectionBehaviour
@@ -34,6 +33,157 @@ if TYPE_CHECKING:
     from amulet_map_editor.programs.edit.api.canvas import EditCanvas
 
 
+class TupleInput(wx.FlexGridSizer):
+    WindowCls: Union[Type[wx.SpinCtrl], Type[wx.SpinCtrlDouble]] = None
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        x_str: str,
+        y_str: str,
+        z_str: str,
+        min_value: int = -30_000_000,
+        max_value: int = 30_000_000,
+        start_value: int = 0,
+        style=wx.SP_ARROW_KEYS,
+    ):
+        super().__init__(3, 2, 5, 5)
+
+        x_label = wx.StaticText(parent, label=x_str)
+        self.Add(x_label, 0, wx.ALIGN_CENTER, 5)
+        self.x = self.WindowCls(
+            parent, min=min_value, max=max_value, initial=start_value, style=style
+        )
+        self.Add(self.x, 0, wx.ALIGN_CENTER, 5)
+
+        y_label = wx.StaticText(parent, label=y_str)
+        self.Add(y_label, 0, wx.ALIGN_CENTER, 5)
+        self.y = self.WindowCls(
+            parent, min=min_value, max=max_value, initial=start_value, style=style
+        )
+        self.Add(self.y, 0, wx.ALIGN_CENTER, 0)
+
+        z_label = wx.StaticText(parent, label=z_str)
+        self.Add(z_label, 0, wx.ALIGN_CENTER, 5)
+        self.z = self.WindowCls(
+            parent, min=min_value, max=max_value, initial=start_value, style=style
+        )
+        self.Add(self.z, 0, wx.ALIGN_CENTER, 0)
+
+    @property
+    def value(self):
+        return self.x.GetValue(), self.y.GetValue(), self.z.GetValue()
+
+    @value.setter
+    def value(self, value):
+        self.x.SetValue(value[0])
+        self.y.SetValue(value[1])
+        self.z.SetValue(value[2])
+
+
+class TupleIntInput(TupleInput):
+    WindowCls = wx.SpinCtrl
+
+    @property
+    def value(self) -> Tuple[int, int, int]:
+        return self.x.GetValue(), self.y.GetValue(), self.z.GetValue()
+
+    @value.setter
+    def value(self, value: Tuple[int, int, int]):
+        self.x.SetValue(value[0])
+        self.y.SetValue(value[1])
+        self.z.SetValue(value[2])
+
+
+class TupleFloatInput(TupleInput):
+    WindowCls = wx.SpinCtrlDouble
+
+    @property
+    def value(self) -> Tuple[float, float, float]:
+        return self.x.GetValue(), self.y.GetValue(), self.z.GetValue()
+
+    @value.setter
+    def value(self, value: Tuple[float, float, float]):
+        self.x.SetValue(value[0])
+        self.y.SetValue(value[1])
+        self.z.SetValue(value[2])
+
+
+class RotationTupleInput(TupleFloatInput):
+    def __init__(
+        self,
+        parent: wx.Window,
+        x_str: str,
+        y_str: str,
+        z_str: str,
+        increment=90,
+    ):
+        super().__init__(
+            parent, x_str, y_str, z_str, -180, 180, style=wx.SP_ARROW_KEYS | wx.SP_WRAP
+        )
+        self.increment = increment
+        self.x.Bind(wx.EVT_MOUSEWHEEL, self._on_wheel)
+        self.y.Bind(wx.EVT_MOUSEWHEEL, self._on_wheel)
+        self.z.Bind(wx.EVT_MOUSEWHEEL, self._on_wheel)
+        self.x.Bind(wx.EVT_SPINCTRLDOUBLE, self._on_change)
+        self.y.Bind(wx.EVT_SPINCTRLDOUBLE, self._on_change)
+        self.z.Bind(wx.EVT_SPINCTRLDOUBLE, self._on_change)
+
+    @property
+    def rotation_radians(self) -> Tuple[float, float, float]:
+        return (
+            math.radians(self.x.GetValue()),
+            math.radians(self.y.GetValue()),
+            math.radians(self.z.GetValue()),
+        )
+
+    @property
+    def increment(self) -> int:
+        return self.x.GetIncrement()
+
+    @increment.setter
+    def increment(self, increment: int):
+        assert isinstance(increment, int) and increment >= 1
+        self.x.SetIncrement(increment)
+        self.y.SetIncrement(increment)
+        self.z.SetIncrement(increment)
+        self._round_values()
+
+    def _on_wheel(self, evt: wx.MouseEvent):
+        rotation = evt.GetWheelRotation()
+        ctrl = evt.GetEventObject()
+        if rotation > 0:
+            ctrl.SetValue(ctrl.GetValue() + ctrl.GetIncrement())
+            self._changed(ctrl)
+        elif rotation < 0:
+            ctrl.SetValue(ctrl.GetValue() - ctrl.GetIncrement())
+            self._changed(ctrl)
+
+    def _on_change(self, evt: wx.SpinDoubleEvent):
+        ctrl = evt.GetEventObject()
+        ctrl.SetValue(
+            int(round(ctrl.GetValue() / ctrl.GetIncrement())) * ctrl.GetIncrement()
+        )
+        evt.SetValue(ctrl.GetValue())
+        evt.Skip()
+
+    def _changed(self, ctrl: wx.SpinCtrlDouble):
+        evt = wx.SpinDoubleEvent(wx.wxEVT_SPINCTRLDOUBLE, ctrl.GetId(), ctrl.GetValue())
+        evt.SetEventObject(ctrl)
+        wx.PostEvent(ctrl, evt)
+
+    def _round_value(self, ctrl: wx.SpinCtrlDouble):
+        ctrl.SetValue(
+            int(round(ctrl.GetValue() / ctrl.GetIncrement())) * ctrl.GetIncrement()
+        )
+        self._changed(ctrl)
+
+    def _round_values(self):
+        self._round_value(self.x)
+        self._round_value(self.y)
+        self._round_value(self.z)
+
+
 class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
     def __init__(self, canvas: "EditCanvas"):
         wx.BoxSizer.__init__(self, wx.HORIZONTAL)
@@ -43,20 +193,103 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._cursor = PointerBehaviour(self.canvas)
         self._moving = False
 
-        self._button_panel = wx.Panel(canvas)
-        self._button_sizer = wx.BoxSizer(wx.VERTICAL)
-        self._button_panel.SetSizer(self._button_sizer)
-        self.Add(self._button_panel, 0, wx.ALIGN_CENTER_VERTICAL)
+        self._paste_panel = wx.Panel(canvas)
+        self._paste_sizer = wx.BoxSizer(wx.VERTICAL)
+        self._paste_panel.SetSizer(self._paste_sizer)
+        self.Add(self._paste_panel, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self._paste_panel = SelectTransformUI(self._button_panel)
-        self._paste_panel.Bind(EVT_TRANSFORM_CHANGE, self._on_transform_change)
-        self._button_sizer.Add(self._paste_panel, 0, wx.EXPAND)
+        self._copy_air = wx.CheckBox(
+            self._paste_panel, label="Copy Air", style=wx.ALIGN_RIGHT
+        )
+        self._paste_sizer.Add(self._copy_air, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
 
-        confirm_button = wx.Button(self._button_panel, label="Confirm")
-        self._button_sizer.Add(confirm_button, 0, wx.ALL | wx.EXPAND, 5)
+        self._copy_water = wx.CheckBox(
+            self._paste_panel, label="Copy Water", style=wx.ALIGN_RIGHT
+        )
+        self._paste_sizer.Add(
+            self._copy_water,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+
+        self._copy_lava = wx.CheckBox(
+            self._paste_panel, label="Copy Lava", style=wx.ALIGN_RIGHT
+        )
+        self._paste_sizer.Add(
+            self._copy_lava,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+
+        self._location = TupleIntInput(self._paste_panel, "x", "y", "z")
+        self._paste_sizer.Add(
+            self._location,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+
+        self._free_rotation = wx.CheckBox(
+            self._paste_panel, label="Free Rotation", style=wx.ALIGN_RIGHT
+        )
+        self._paste_sizer.Add(
+            self._free_rotation,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+
+        self._rotation = RotationTupleInput(self._paste_panel, "rx", "ry", "rz")
+        self._paste_sizer.Add(
+            self._rotation,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+        self._free_rotation.Bind(wx.EVT_CHECKBOX, self._on_free_rotation_change)
+
+        sizer_6 = wx.BoxSizer(wx.HORIZONTAL)
+        self._paste_sizer.Add(
+            sizer_6, 1, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT, 5
+        )
+
+        self.button_3 = wx.Button(self._paste_panel, label="a")
+        self.button_3.SetMinSize((30, 30))
+        sizer_6.Add(self.button_3, 0, 0, 0)
+
+        self.button_4 = wx.Button(self._paste_panel, label="a")
+        self.button_4.SetMinSize((30, 30))
+        sizer_6.Add(self.button_4, 0, 0, 0)
+
+        self._scale = TupleFloatInput(
+            self._paste_panel, "sx", "sy", "sz", start_value=1
+        )
+        self._paste_sizer.Add(
+            self._scale,
+            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+
+        self._paste_panel.Bind(wx.EVT_SPINCTRL, self._on_transform_change)
+        self._paste_panel.Bind(wx.EVT_SPINCTRLDOUBLE, self._on_transform_change)
+
+        sizer_5 = wx.BoxSizer(wx.HORIZONTAL)
+        self._paste_sizer.Add(
+            sizer_5, 1, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT, 5
+        )
+
+        self.button_1 = wx.Button(self._paste_panel, label="a")
+        self.button_1.SetMinSize((30, 30))
+        sizer_5.Add(self.button_1, 0, 0, 0)
+
+        self.button_2 = wx.Button(self._paste_panel, label="a")
+        self.button_2.SetMinSize((30, 30))
+        sizer_5.Add(self.button_2, 0, 0, 0)
+
+        confirm_button = wx.Button(self._paste_panel, label="Confirm")
+        self._paste_sizer.Add(
+            confirm_button, 0, wx.BOTTOM | wx.LEFT | wx.RIGHT | wx.EXPAND, 5
+        )
         confirm_button.Bind(wx.EVT_BUTTON, self._paste_confirm)
 
-        self._button_panel.Disable()
+        self._paste_panel.Disable()
         self.Layout()
 
     @property
@@ -78,24 +311,33 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
 
     def disable(self):
         super().disable()
-        self._button_panel.Disable()
+        self._paste_panel.Disable()
         self.canvas.renderer.fake_levels.clear()
+
+    def _on_free_rotation_change(self, evt):
+        if self._free_rotation.GetValue():
+            self._rotation.increment = 1
+        else:
+            self._rotation.increment = 90
+
+    def _rotation_radians(self) -> Tuple[float, float, float]:
+        return tuple(math.radians(v) for v in self._rotation.value)
 
     def _on_pointer_change(self, evt: PointChangeEvent):
         if self._moving:
             self.canvas.renderer.fake_levels.active_transform = (
                 evt.point,
-                self._paste_panel.scale,
-                self._paste_panel.rotation_radians,
+                self._scale.value,
+                self._rotation_radians(),
             )
-            self._paste_panel.location = evt.point
+            self._location.value = evt.point
         evt.Skip()
 
     def _on_transform_change(self, evt: TransformChangeEvent):
         self.canvas.renderer.fake_levels.active_transform = (
-            evt.location,
-            evt.scale,
-            evt.rotation_radians,
+            self._location.value,
+            self._scale.value,
+            self._rotation_radians(),
         )
         evt.Skip()
 
@@ -104,14 +346,14 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             self._moving = not self._moving
             if self._moving:
                 self.canvas.renderer.fake_levels.active_transform = (
-                    self._paste_panel.location,
-                    self._paste_panel.scale,
-                    self._paste_panel.rotation_radians,
+                    self._location.value,
+                    self._scale.value,
+                    self._rotation_radians(),
                 )
         evt.Skip()
 
     def _paste(self, evt):
-        self._button_panel.Enable()
+        self._paste_panel.Enable()
         structure = evt.structure
         dimension = evt.dimension
         self.canvas.renderer.fake_levels.clear()
@@ -131,12 +373,12 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
                     self.canvas.dimension,
                     render_level.level,
                     render_level.dimension,
-                    self._paste_panel.location,
-                    self._paste_panel.scale,
-                    self._paste_panel.rotation,
-                    self._paste_panel.copy_air,
-                    self._paste_panel.copy_water,
-                    self._paste_panel.copy_lava,
+                    self._location.value,
+                    self._scale.value,
+                    self._rotation.value,
+                    self._copy_air.GetValue(),
+                    self._copy_water.GetValue(),
+                    self._copy_lava.GetValue(),
                 )
             )
 

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -290,9 +290,15 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             lang.get("program_3d_edit.paste_tool.location_y_label"),
             lang.get("program_3d_edit.paste_tool.location_z_label"),
         )
-        self._location.x.SetToolTip(lang.get("program_3d_edit.paste_tool.location_x_tooltip"))
-        self._location.y.SetToolTip(lang.get("program_3d_edit.paste_tool.location_y_tooltip"))
-        self._location.z.SetToolTip(lang.get("program_3d_edit.paste_tool.location_z_tooltip"))
+        self._location.x.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.location_x_tooltip")
+        )
+        self._location.y.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.location_y_tooltip")
+        )
+        self._location.z.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.location_z_tooltip")
+        )
         self._paste_sizer.Add(
             self._location,
             flag=BottomLeftRightExpand,
@@ -317,9 +323,12 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
 
         add_label(lang.get("program_3d_edit.paste_tool.rotation_label"))
         self._free_rotation = wx.CheckBox(
-            self._paste_panel, label=lang.get("program_3d_edit.paste_tool.free_rotation_label")
+            self._paste_panel,
+            label=lang.get("program_3d_edit.paste_tool.free_rotation_label"),
         )
-        self._free_rotation.SetToolTip(lang.get("program_3d_edit.paste_tool.free_rotation_tooltip"))
+        self._free_rotation.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.free_rotation_tooltip")
+        )
         self._paste_sizer.Add(
             self._free_rotation,
             flag=BottomLeftRight,
@@ -332,9 +341,15 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             lang.get("program_3d_edit.paste_tool.rotation_y_label"),
             lang.get("program_3d_edit.paste_tool.rotation_z_label"),
         )
-        self._rotation.x.SetToolTip(lang.get("program_3d_edit.paste_tool.rotation_x_tooltip"))
-        self._rotation.y.SetToolTip(lang.get("program_3d_edit.paste_tool.rotation_y_tooltip"))
-        self._rotation.z.SetToolTip(lang.get("program_3d_edit.paste_tool.rotation_z_tooltip"))
+        self._rotation.x.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.rotation_x_tooltip")
+        )
+        self._rotation.y.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.rotation_y_tooltip")
+        )
+        self._rotation.z.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.rotation_z_tooltip")
+        )
         self._paste_sizer.Add(
             self._rotation,
             flag=BottomLeftRightExpand,
@@ -352,7 +367,9 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._rotate_left_button = wx.BitmapButton(
             self._paste_panel, bitmap=image.icon.tablericons.rotate_2.bitmap(22, 22)
         )
-        self._rotate_left_button.SetToolTip(lang.get("program_3d_edit.paste_tool.rotate_anti_clockwise_tooltip"))
+        self._rotate_left_button.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.rotate_anti_clockwise_tooltip")
+        )
         self._rotate_left_button.Bind(wx.EVT_BUTTON, self._on_rotate_left)
         rotate_sizer.Add(self._rotate_left_button)
 
@@ -360,7 +377,9 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             self._paste_panel,
             bitmap=image.icon.tablericons.rotate_clockwise_2.bitmap(22, 22),
         )
-        self._rotate_right_button.SetToolTip(lang.get("program_3d_edit.paste_tool.rotate_clockwise_tooltip"))
+        self._rotate_right_button.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.rotate_clockwise_tooltip")
+        )
         self._rotate_right_button.Bind(wx.EVT_BUTTON, self._on_rotate_right)
         rotate_sizer.Add(self._rotate_right_button)
 
@@ -372,7 +391,7 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             lang.get("program_3d_edit.paste_tool.scale_x_label"),
             lang.get("program_3d_edit.paste_tool.scale_y_label"),
             lang.get("program_3d_edit.paste_tool.scale_z_label"),
-            start_value=1
+            start_value=1,
         )
         self._scale.x.SetToolTip(lang.get("program_3d_edit.paste_tool.scale_x_tooltip"))
         self._scale.y.SetToolTip(lang.get("program_3d_edit.paste_tool.scale_y_tooltip"))
@@ -401,7 +420,9 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             self._paste_panel,
             bitmap=image.icon.tablericons.flip_vertical.bitmap(22, 22),
         )
-        self._mirror_horizontal_button.SetToolTip(lang.get("program_3d_edit.paste_tool.mirror_horizontal_tooltip"))
+        self._mirror_horizontal_button.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.mirror_horizontal_tooltip")
+        )
         self._mirror_horizontal_button.Bind(wx.EVT_BUTTON, self._on_mirror_horizontal)
         mirror_sizer.Add(self._mirror_horizontal_button)
 
@@ -409,18 +430,32 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             self._paste_panel,
             bitmap=image.icon.tablericons.flip_horizontal.bitmap(22, 22),
         )
-        self._mirror_vertical_button.SetToolTip(lang.get("program_3d_edit.paste_tool.mirror_vertical_tooltip"))
+        self._mirror_vertical_button.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.mirror_vertical_tooltip")
+        )
         self._mirror_vertical_button.Bind(wx.EVT_BUTTON, self._on_mirror_vertical)
         mirror_sizer.Add(self._mirror_vertical_button)
 
         add_line()
 
-        self._copy_air = add_tick_box(lang.get("program_3d_edit.paste_tool.copy_air_label"))
-        self._copy_air.SetToolTip(lang.get("program_3d_edit.paste_tool.copy_air_tooltip"))
-        self._copy_water = add_tick_box(lang.get("program_3d_edit.paste_tool.copy_water_label"))
-        self._copy_water.SetToolTip(lang.get("program_3d_edit.paste_tool.copy_water_tooltip"))
-        self._copy_lava = add_tick_box(lang.get("program_3d_edit.paste_tool.copy_lava_label"))
-        self._copy_lava.SetToolTip(lang.get("program_3d_edit.paste_tool.copy_lava_tooltip"))
+        self._copy_air = add_tick_box(
+            lang.get("program_3d_edit.paste_tool.copy_air_label")
+        )
+        self._copy_air.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.copy_air_tooltip")
+        )
+        self._copy_water = add_tick_box(
+            lang.get("program_3d_edit.paste_tool.copy_water_label")
+        )
+        self._copy_water.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.copy_water_tooltip")
+        )
+        self._copy_lava = add_tick_box(
+            lang.get("program_3d_edit.paste_tool.copy_lava_label")
+        )
+        self._copy_lava.SetToolTip(
+            lang.get("program_3d_edit.paste_tool.copy_lava_tooltip")
+        )
 
         add_line()
 

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -146,6 +146,16 @@ class RotationTupleInput(TupleFloatInput):
         self.z.Bind(wx.EVT_SPINCTRLDOUBLE, self._on_change)
 
     @property
+    def value(self) -> Tuple[float, float, float]:
+        return self.x.GetValue(), self.y.GetValue(), self.z.GetValue()
+
+    @value.setter
+    def value(self, value: Tuple[float, float, float]):
+        self.x.SetValue(round(value[0]))
+        self.y.SetValue(round(value[1]))
+        self.z.SetValue(round(value[2]))
+
+    @property
     def rotation_radians(self) -> Tuple[float, float, float]:
         return (
             math.radians(self.x.GetValue()),

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -43,6 +43,10 @@ from amulet_map_editor.programs.edit.api.key_config import (
 if TYPE_CHECKING:
     from amulet_map_editor.programs.edit.api.canvas import EditCanvas
 
+BottomLeftRight = wx.BOTTOM | wx.LEFT | wx.RIGHT
+BottomLeftRightCentre = BottomLeftRight | wx.ALIGN_CENTER_HORIZONTAL
+BottomLeftRightExpand = BottomLeftRight | wx.EXPAND
+
 
 class TupleInput(wx.FlexGridSizer):
     WindowCls: Union[Type[wx.SpinCtrl], Type[wx.SpinCtrlDouble]] = None
@@ -61,25 +65,26 @@ class TupleInput(wx.FlexGridSizer):
         super().__init__(3, 2, 5, 5)
 
         x_label = wx.StaticText(parent, label=x_str)
-        self.Add(x_label, 0, wx.ALIGN_CENTER, 5)
+        self.Add(x_label, 0, wx.ALIGN_CENTER)
         self.x = self.WindowCls(
             parent, min=min_value, max=max_value, initial=start_value, style=style
         )
-        self.Add(self.x, 0, wx.ALIGN_CENTER, 5)
+        self.Add(self.x, 0, wx.EXPAND)
 
         y_label = wx.StaticText(parent, label=y_str)
-        self.Add(y_label, 0, wx.ALIGN_CENTER, 5)
+        self.Add(y_label, 0, wx.ALIGN_CENTER)
         self.y = self.WindowCls(
             parent, min=min_value, max=max_value, initial=start_value, style=style
         )
-        self.Add(self.y, 0, wx.ALIGN_CENTER, 0)
+        self.Add(self.y, 0, wx.EXPAND)
 
         z_label = wx.StaticText(parent, label=z_str)
-        self.Add(z_label, 0, wx.ALIGN_CENTER, 5)
+        self.Add(z_label, 0, wx.ALIGN_CENTER)
         self.z = self.WindowCls(
             parent, min=min_value, max=max_value, initial=start_value, style=style
         )
-        self.Add(self.z, 0, wx.ALIGN_CENTER, 0)
+        self.Add(self.z, 0, wx.EXPAND)
+        self.AddGrowableCol(1)
 
     @property
     def value(self):
@@ -228,33 +233,40 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._paste_panel.SetSizer(self._paste_sizer)
         self.Add(self._paste_panel, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        self._copy_air = wx.CheckBox(
-            self._paste_panel, label="Copy Air", style=wx.ALIGN_RIGHT
-        )
-        self._paste_sizer.Add(self._copy_air, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
+        def add_line():
+            """add a line to the UI"""
+            line = wx.StaticLine(self._paste_panel)
+            self._paste_sizer.Add(line, 0, wx.BOTTOM | wx.EXPAND, 5)
 
-        self._copy_water = wx.CheckBox(
-            self._paste_panel, label="Copy Water", style=wx.ALIGN_RIGHT
-        )
-        self._paste_sizer.Add(
-            self._copy_water,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
-            border=5,
-        )
+        def add_tick_box(name: str, state: bool = True):
+            tick = wx.CheckBox(self._paste_panel, label=name, style=wx.ALIGN_RIGHT)
+            tick.SetValue(state)
+            self._paste_sizer.Add(
+                tick,
+                flag=BottomLeftRightCentre,
+                border=5,
+            )
+            return tick
 
-        self._copy_lava = wx.CheckBox(
-            self._paste_panel, label="Copy Lava", style=wx.ALIGN_RIGHT
-        )
-        self._paste_sizer.Add(
-            self._copy_lava,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
-            border=5,
-        )
+        def add_label(name: str):
+            label = wx.StaticText(self._paste_panel, label=name)
+            label.SetFont(
+                wx.Font(
+                    12,
+                    wx.FONTFAMILY_DEFAULT,
+                    wx.FONTSTYLE_NORMAL,
+                    wx.FONTWEIGHT_NORMAL,
+                    True,
+                )
+            )
+            self._paste_sizer.Add(label, 0, BottomLeftRightCentre, 5)
 
+        self._paste_sizer.AddSpacer(5)
+        add_label("Location")
         self._location = TupleIntInput(self._paste_panel, "x", "y", "z")
         self._paste_sizer.Add(
             self._location,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            flag=BottomLeftRightExpand,
             border=5,
         )
 
@@ -268,23 +280,26 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         )
         self._paste_sizer.Add(
             self._move_button,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            flag=BottomLeftRightCentre,
             border=5,
         )
 
+        add_line()
+
+        add_label("Rotation")
         self._free_rotation = wx.CheckBox(
             self._paste_panel, label="Free Rotation", style=wx.ALIGN_RIGHT
         )
         self._paste_sizer.Add(
             self._free_rotation,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            flag=BottomLeftRightCentre,
             border=5,
         )
 
-        self._rotation = RotationTupleInput(self._paste_panel, "rx", "ry", "rz")
+        self._rotation = RotationTupleInput(self._paste_panel, "x", "y", "z")
         self._paste_sizer.Add(
             self._rotation,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            flag=BottomLeftRightExpand,
             border=5,
         )
         self._free_rotation.Bind(wx.EVT_CHECKBOX, self._on_free_rotation_change)
@@ -292,9 +307,8 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         rotate_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self._paste_sizer.Add(
             rotate_sizer,
-            1,
-            wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
-            5,
+            flag=BottomLeftRightCentre,
+            border=5,
         )
 
         self._rotate_left_button = wx.BitmapButton(
@@ -310,12 +324,13 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._rotate_right_button.Bind(wx.EVT_BUTTON, self._on_rotate_right)
         rotate_sizer.Add(self._rotate_right_button, 0, 0, 0)
 
-        self._scale = TupleFloatInput(
-            self._paste_panel, "sx", "sy", "sz", start_value=1
-        )
+        add_line()
+
+        add_label("Scale")
+        self._scale = TupleFloatInput(self._paste_panel, "x", "y", "z", start_value=1)
         self._paste_sizer.Add(
             self._scale,
-            flag=wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
+            flag=BottomLeftRightExpand,
             border=5,
         )
 
@@ -325,9 +340,8 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         mirror_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self._paste_sizer.Add(
             mirror_sizer,
-            1,
-            wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM | wx.LEFT | wx.RIGHT,
-            5,
+            flag=BottomLeftRightCentre,
+            border=5,
         )
 
         # the tablericons file names are the wrong way around
@@ -345,10 +359,16 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
         self._mirror_vertical_button.Bind(wx.EVT_BUTTON, self._on_mirror_vertical)
         mirror_sizer.Add(self._mirror_vertical_button, 0, 0, 0)
 
+        add_line()
+
+        self._copy_air = add_tick_box("Copy Air")
+        self._copy_water = add_tick_box("Copy Water")
+        self._copy_lava = add_tick_box("Copy Lava")
+
+        add_line()
+
         confirm_button = wx.Button(self._paste_panel, label="Confirm")
-        self._paste_sizer.Add(
-            confirm_button, 0, wx.BOTTOM | wx.LEFT | wx.RIGHT | wx.EXPAND, 5
-        )
+        self._paste_sizer.Add(confirm_button, 0, BottomLeftRightExpand, 5)
         confirm_button.Bind(wx.EVT_BUTTON, self._paste_confirm)
 
         self._paste_panel.Disable()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wxPython ; sys_platform != 'linux'
 numpy
 pyopengl
-amulet-core~=1.2.3
+amulet-core~=1.2.4
 amulet-nbt~=1.0.3
 pymctranslate~=1.0.0
 minecraft-resource-pack~=1.2.0


### PR DESCRIPTION
This is a large overhaul of the paste tool.
It adds a nudge button to move around the pasted selection.
It adds the ability to scale the pasted structure in each axis.
It adds the ability to mirror the structure through negative scale values.
It adds rotation in degree increments which can be enabled by the free rotation toggle.
Added buttons to rotate and mirror based on the camera's orientation.
Redesigned the UI to make it easier to understand.

Made the matrices in the camera class immutable.

Requires Amulet-Team/Amulet-Core/pull/127