### PR TITLE
Fixed program freeze

### DIFF
--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -125,7 +125,7 @@ class ButtonInput(WindowContainer):
         )
 
         # save destruction
-        self.window.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
+        self.window.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy, self.window)
 
     def enable(self):
         self._input_timer.Start(33)

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -87,7 +87,7 @@ class Renderer(EditCanvasContainer):
             self._draw_timer,
         )
         self.canvas.Bind(EVT_CAMERA_MOVED, self._on_camera_moved)
-        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
+        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy, self.canvas)
 
     def enable(self):
         """Enable and start working."""

--- a/amulet_map_editor/programs/edit/api/selection.py
+++ b/amulet_map_editor/programs/edit/api/selection.py
@@ -43,7 +43,7 @@ class SelectionManager(Changeable):
     def bind_events(self):
         """Set up all events required to run."""
         self.canvas.Bind(wx.EVT_TIMER, self._create_undo_point, self._timer)
-        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
+        self.canvas.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy, self.canvas)
 
     def _create_undo_point(self, evt):
         self.canvas.create_undo_point(False, True)


### PR DESCRIPTION
This was caused by an operation being destroyed.
The event propagated upwards and was caught by these events when it should not have been.
This makes it so that they will only receive the event if the parent is the one creating the event.