### PR TITLE
Fall back to default language if language is None

### DIFF
--- a/amulet_map_editor/api/lang.py
+++ b/amulet_map_editor/api/lang.py
@@ -25,6 +25,9 @@ except:
 # if a language is set in the config use that
 _language = CONFIG.get("amulet_meta", {}).get("lang", _language)
 
+if _language is None:
+    _language = _default_language
+
 
 def register_lang_directory(lang_dir: str):
     """Register a new language directory.


### PR DESCRIPTION
locale.getdefaultlanguage can return None if the language cannot be found.

Fixes #283 