### PR TITLE
Locked pyinstaller to 4.2

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pyinstaller
+        pip install setuptools wheel twine pyinstaller==4.2
         pip install -r requirements.txt
 
     # setup


### PR DESCRIPTION
We will remove this at some point in the future when the new version does not trip antivirus programs up