### PR TITLE
Add comments support for lang files

### DIFF
--- a/amulet_map_editor/api/lang.py
+++ b/amulet_map_editor/api/lang.py
@@ -91,11 +91,13 @@ def _load_lang_file(lang_path: str) -> Dict[str, str]:
     if os.path.isfile(lang_path):
         with open(lang_path, encoding="utf-8") as f:
             for line in f.readlines():
-                split_line = line.split("=", 1)
-                if len(split_line) == 2:
-                    unique_identifier = split_line[0].strip()
-                    language_string = split_line[1].replace("\\n", "\n").strip()
-                    lang[unique_identifier] = language_string
+                lstrip_line = line.lstrip()
+                if not lstrip_line.startswith("#"):
+                    split_line = lstrip_line.split("=", 1)
+                    if len(split_line) == 2:
+                        unique_identifier = split_line[0].rstrip()
+                        language_string = split_line[1].replace("\\n", "\n").strip()
+                        lang[unique_identifier] = language_string
     return lang
 
 

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -1,9 +1,58 @@
+# Important notes
+## If you want to contribute to the translation of the User Interface (UI), please read the corresponding contribution file located at '/contributing/lang.md'
+## Each translation entry must be written as follows: 'unique.identifier=The text shown in the UI'
+## Unique identifiers are defined by the devs. In order to know what are the existing identifiers, please refer to the 'en.lang' file
+
+# Loading order and region specific translations
+## First the 'en.lang' is loaded to ensure that there is at least something for any given key
+## Then, if the language code contains an "_" symbol (for example "fr_CA"), the lang file for the language section ("fr") will be loaded next ("fr.lang")
+## Finally, if it exists, the region specific language file ("fr_CA.lang") will be loaded which should only contain entries that vary between regions
+## This allows languages that do not vary much between regions to share the same language file to minimise duplication
+
+# Supported features in translation files
+## You can write a comment line by using the "#" symbol as the first (non-space) character of a line. Inline comments are not supported
+## Any "\n" in a translation string will be converted as a new line in the UI
+
+# About the menu bar
+## The "&" symbol is a special character in this context. It will not be shown in the UI but will define the following character as a shortcut when the "alt" key is pressed (warning: accented letters are they own characters (é =/= e))
+## Example: "&File" translates to "File" in the UI, but will allow the user to press "alt+f" to open the corresponding menu
+## More info can be found at: https://docs.wxpython.org/wx.MenuItem.html#wx.MenuItem.SetItemLabel
+
+
+
+# App
 app.world_still_used=A world is still being used. Please close it first
 
 world.java_platform=Java
 world.bedrock_platform=Bedrock
 world.close_world=Close World
 
+# Menu bar
+## The menu displayed at the top of the screen
+menu_bar.file.menu_name=&File
+menu_bar.file.open_world=Open World
+menu_bar.file.close_world=Close World
+menu_bar.file.quit=Quit
+menu_bar.options.menu_name=&Options
+menu_bar.help.menu_name=&Help
+
+# Main menu
+## The start screen
+main_menu.tab_name=Main Menu
+main_menu.open_world=Open World
+main_menu.help=Help
+main_menu.discord=Amulet Discord
+
+# Update check
+## The window displayed when a newer version of Amulet is available
+update_check.newer_version_released=A new version of Amulet has been released!
+update_check.new_version=New Version:
+update_check.current_version=Your Version:
+update_check.update=Go to Download Page
+update_check.ok=Ok
+
+# Select world
+## The window when selecting a world to open
 select_world.title=World Select
 select_world.open_world_warning=Close the world in game and other tools before opening in Amulet.
 select_world.open_world_button=Open other world
@@ -13,28 +62,14 @@ select_world.recent_worlds=Recently Opened Worlds
 select_world.no_loader_found=Could not find a loader for this world.
 select_world.loading_world_failed=Error loading world. Check the console for more details.
 
-main_menu.tab_name=Main Menu
-main_menu.open_world=Open World
-main_menu.help=Help
-main_menu.discord=Amulet Discord
-
-menu_bar.file.menu_name=&File
-menu_bar.file.open_world=Open World
-menu_bar.file.close_world=Close World
-menu_bar.file.quit=Quit
-menu_bar.options.menu_name=&Options
-menu_bar.help.menu_name=&Help
-
-update_check.newer_version_released=A new version of Amulet has been released!
-update_check.new_version=New Version:
-update_check.current_version=Your Version:
-update_check.update=Go to Download Page
-update_check.ok=Ok
-
+# About
+## The default program when a world is opened
 program_about.tab_name=About
 program_about.currently_opened_world=Currently Opened World:
 program_about.choose_from_options=Choose from the options on the left what you would like to do.\nYou can switch between these at any time.
 
+# Convert
+## The program used to convert a world
 program_convert.tab_name=Convert
 program_convert.convert_button=Convert
 program_convert.input_world=Input World:
@@ -44,8 +79,35 @@ program_convert.input_output_must_different=The input and output worlds must be 
 program_convert.select_before_converting=Select a world before converting!
 program_convert.conversion_completed=World conversion completed
 
+# 3D Editor
+## The program used to edit a world with a 3D viewer
 program_3d_edit.tab_name=3D Editor
 
+## Canvas
+program_3d_edit.canvas.please_wait=Please wait while the renderer loads
+program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Downloading Bedrock vanilla resource pack
+program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Downloading Java vanilla resource pack
+program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Failed to download the latest Java resource pack.\nCheck your internet connection and restart Amulet.\nCheck the console for more details.
+program_3d_edit.canvas.loading_resource_packs=Loading resource packs
+program_3d_edit.canvas.creating_texture_atlas=Creating texture atlas
+program_3d_edit.canvas.setting_up_renderer=Setting up renderer
+
+## Menu bar
+program_3d_edit.menu_bar.file.save=Save
+program_3d_edit.menu_bar.edit.menu_name=&Edit
+program_3d_edit.menu_bar.edit.undo=Undo
+program_3d_edit.menu_bar.edit.redo=Redo
+program_3d_edit.menu_bar.edit.cut=Cut
+program_3d_edit.menu_bar.edit.copy=Copy
+program_3d_edit.menu_bar.edit.paste=Paste
+program_3d_edit.menu_bar.edit.delete=Delete
+program_3d_edit.menu_bar.edit.goto=Goto
+program_3d_edit.menu_bar.edit.select_all=Select All
+program_3d_edit.menu_bar.options.controls=Controls...
+program_3d_edit.menu_bar.options.options=Options...
+program_3d_edit.menu_bar.help.controls=Controls
+
+## Select tool
 program_3d_edit.select_tool.delete_button=Delete
 program_3d_edit.select_tool.delete_button_tooltip=Delete the blocks in the selected area.
 program_3d_edit.select_tool.copy_button=Copy
@@ -66,7 +128,6 @@ program_3d_edit.select_tool.scroll_point_z1_tooltip=Set the z coordinate of the 
 program_3d_edit.select_tool.scroll_point_x2_tooltip=Set the x coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
 program_3d_edit.select_tool.scroll_point_y2_tooltip=Set the y coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
 program_3d_edit.select_tool.scroll_point_z2_tooltip=Set the z coordinate of the active box's blue corner. Type a number or scroll wheel while hovering.
-
 program_3d_edit.select_tool.box_size_selector_fstring=dx={x},dy={y},dz={z}
 program_3d_edit.select_tool.box_size_selector_tooltip=The shape of the active selection using Minecraft volume selector notation.
 program_3d_edit.select_tool.box_size_tooltip=The size of the active selection box in blocks.
@@ -77,6 +138,7 @@ program_3d_edit.select_tool.button_point2_tooltip=Press and hold this button and
 program_3d_edit.select_tool.button_selection_box=Move Box
 program_3d_edit.select_tool.button_selection_box_tooltip=Press and hold this button and use the movement controls to move the active box.
 
+## Paste tool
 program_3d_edit.paste_tool.location_label=Location
 program_3d_edit.paste_tool.location_x_label=x
 program_3d_edit.paste_tool.location_x_tooltip=The x location where the centre of the selection will be placed. Type in a number, scroll wheel over or use the arrows to change.
@@ -116,6 +178,7 @@ program_3d_edit.paste_tool.confirm_label=Confirm
 program_3d_edit.paste_tool.confirm_tooltip=Click to paste the structure into the world and the specified location, rotation and scale.
 program_3d_edit.paste_tool.zero_scale_message=One of the scale values had a value of zero so nothing was copied.
 
+## Chunk tool
 program_3d_edit.chunk_tool.min_y=Min Y
 program_3d_edit.chunk_tool.min_y_tooltip=The minimum y coordinate to draw in the top down view. This can be used to view a slice of the world and help view dimensions like the nether and caves.
 program_3d_edit.chunk_tool.max_y=Max Y
@@ -125,6 +188,7 @@ program_3d_edit.chunk_tool.delete_chunks_tooltip=Delete the selected chunks. Thi
 program_3d_edit.chunk_tool.prune_chunks=Prune Chunks
 program_3d_edit.chunk_tool.prune_chunks_tooltip=Delete all chunks that are not selected. This will delete the actual chunk and all the data contained within it. Next time you load the area in game it will recreate the chunks.
 
+## Goto/Teleport window
 program_3d_edit.goto_ui.title=Teleport
 program_3d_edit.goto_ui.x_label=x:
 program_3d_edit.goto_ui.x_label_tooltip=The x coordinate of the camera. Type a coordinate to go to the location. Ctrl + C to copy the coordinate. Ctrl + V to paste.
@@ -134,25 +198,3 @@ program_3d_edit.goto_ui.z_label=z:
 program_3d_edit.goto_ui.z_label_tooltip=The z coordinate of the camera. Type a coordinate to go to the location. Ctrl + C to copy the coordinate. Ctrl + V to paste.
 program_3d_edit.goto_ui.copy_button_tooltip=Copy the x, y and z values to the clipboard in the form "0.0 0.0 0.0" (x, y and z respectively)
 program_3d_edit.goto_ui.paste_button_tooltip=Paste a previously copied coordinate into the inputs. Copied value must three numbers separated with spaces or commas.
-
-program_3d_edit.canvas.please_wait=Please wait while the renderer loads
-program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Downloading Bedrock vanilla resource pack
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Downloading Java vanilla resource pack
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Failed to download the latest Java resource pack.\nCheck your internet connection and restart Amulet.\nCheck the console for more details.
-program_3d_edit.canvas.loading_resource_packs=Loading resource packs
-program_3d_edit.canvas.creating_texture_atlas=Creating texture atlas
-program_3d_edit.canvas.setting_up_renderer=Setting up renderer
-
-program_3d_edit.menu_bar.file.save=Save
-program_3d_edit.menu_bar.edit.menu_name=&Edit
-program_3d_edit.menu_bar.edit.undo=Undo
-program_3d_edit.menu_bar.edit.redo=Redo
-program_3d_edit.menu_bar.edit.cut=Cut
-program_3d_edit.menu_bar.edit.copy=Copy
-program_3d_edit.menu_bar.edit.paste=Paste
-program_3d_edit.menu_bar.edit.delete=Delete
-program_3d_edit.menu_bar.edit.goto=Goto
-program_3d_edit.menu_bar.edit.select_all=Select All
-program_3d_edit.menu_bar.options.controls=Controls...
-program_3d_edit.menu_bar.options.options=Options...
-program_3d_edit.menu_bar.help.controls=Controls

--- a/amulet_map_editor/lang/fr.lang
+++ b/amulet_map_editor/lang/fr.lang
@@ -1,22 +1,34 @@
+# Notes importantes
+## Si vous shouaitez contribuer à la traduction de l'Interface Utilisateur (UI), veuillez lire le fichier de contribution correspondant situé à '/contributing/lang.md'
+## Chaque entrée de traduction doit être écrite comme suit : 'identifiant.unique=Le texte affiché dans le UI'
+## Les identifiants uniques sont définis par les développeurs. Pour savoir quels sont les identifiants existants, veuillez vous référer au fichier 'en.lang'
+
+# Ordre de chargement et traductions spécifiques à certaines régions
+## Premièrement, le fichier 'en.lang' est chargé pour s'assurer qu'il y ait au moins quelque chose pour chaque entrée
+## Ensuite, si le code de langue contient le symbole "_" (par exemple "fr_CA"), le fichier pour la section de langue ("fr") est chargé ("fr.lang")
+## Enfin, s'il existe, le fichier pour la région spécifique ("fr_CA.lang") est chargé. Il doit contenir uniquement les entrées qui varient pour la région donnée
+## Cela permet aux langues qui ne changent pas ou peu en fonction des régions de partager le même fichier de traduction et de minimiser les duplications de contenu
+
+# Fonctionnalités supportées dans les fichiers de traduction
+## Vous pouvez écrire une ligne de commentaires en utilisant le symbole "#" en tant que premier caractère d'une ligne (espaces non compris). Les commentaires au sein du texte ne sont pas pris en charge
+## Tout "\n" dans une traduction sera converti en une nouvelle ligne dans le UI
+
+# À propos de la barre de menu
+## Le symbole "&" est un caractère spécial dans ce contexte. Il ne sera pas affiché dans le UI mais définira le caractère suivant comme étant un raccourci en combinaison de la touche "alt" (attention : les lettres accentuées sont leur propre caractère (é =/= e))
+## Exemple : "&Fichier" sera traduit en "Fichier" dans le UI, mais permettra à l'utilisateur d'appuyer sur "alt+f" pour ouvrir le menu correspondant
+## Plus d'informations peuvent être trouvées à : https://docs.wxpython.org/wx.MenuItem.html#wx.MenuItem.SetItemLabel
+
+
+
+# Application
 app.world_still_used=Un monde est toujours en cours d'utilisation. Veuillez d'abord le fermer.
 
 world.java_platform=Java
 world.bedrock_platform=Bedrock
 world.close_world=Fermer le monde
 
-select_world.title=Sélection du monde
-select_world.open_world_button=Ouvrir un monde
-select_world.open_world_dialogue=Sélectionnez un dossier de monde Minecraft
-select_world.select_directory_failed=Impossible d'ouvrir ce dossier !
-select_world.recent_worlds=Mondes récents
-select_world.no_loader_found=Aucun loader n'a été trouvé pour charger ce monde.
-select_world.loading_world_failed=Erreur lors du chargement du monde. Regardez la console pour plus de détails.
-
-main_menu.tab_name=Menu Principal
-main_menu.open_world=Ouvrir un monde
-main_menu.help=Aide
-main_menu.discord=Discord d'Amulet
-
+# Barre de menu
+## Le menu affiché tout en haut de l'écran
 menu_bar.file.menu_name=&Fichier
 menu_bar.file.open_world=Ouvrir un monde
 menu_bar.file.close_world=Fermer le monde
@@ -24,16 +36,40 @@ menu_bar.file.quit=Quitter
 menu_bar.options.menu_name=&Options
 menu_bar.help.menu_name=&Aide
 
+# Menu principal
+## L'écran d'accueil
+main_menu.tab_name=Menu Principal
+main_menu.open_world=Ouvrir un monde
+main_menu.help=Aide
+main_menu.discord=Discord d'Amulet
+
+# Vérification de mise à jour
+## La fenêtre affichée lorsqu'une version plus récente d'Amulet est disponible
 update_check.newer_version_released=Une nouvelle version d'Amulet est disponible !
 update_check.new_version=Nouvelle version :
 update_check.current_version=Votre version :
 update_check.update=Voir la page de téléchargement
 update_check.ok=Ignorer
 
+# Sélection du monde
+## La fenêtre lorsqu'on choisit un monde à ouvrir
+select_world.title=Sélection du monde
+select_world.open_world_warning=Fermez le monde dans le jeu ou tout autre outil avant de l'ouvrir dans Amulet.
+select_world.open_world_button=Ouvrir un monde
+select_world.open_world_dialogue=Sélectionnez un dossier de monde Minecraft
+select_world.select_directory_failed=Impossible d'ouvrir ce dossier !
+select_world.recent_worlds=Mondes récents
+select_world.no_loader_found=Aucun loader n'a été trouvé pour charger ce monde.
+select_world.loading_world_failed=Erreur lors du chargement du monde. Regardez la console pour plus de détails.
+
+# À propos
+## Le programme par défaut lorsqu'on ouvre un monde
 program_about.tab_name=À propos
 program_about.currently_opened_world=Monde actuellement ouvert :
 program_about.choose_from_options=Choisissez une opération parmi les options à gauche.\nVous pouvez changer à tout moment.
 
+# Convertir
+## Le programme utilisé pour convertir un monde
 program_convert.tab_name=Convertir
 program_convert.convert_button=Convertir
 program_convert.input_world=Monde source :
@@ -43,8 +79,35 @@ program_convert.input_output_must_different=Les mondes source et de destination 
 program_convert.select_before_converting=Sélectionnez un monde avant de convertir !
 program_convert.conversion_completed=Conversion terminée
 
+# Éditeur 3D
+## Le programme utilisé pour modifier un monde avec une interface 3D
 program_3d_edit.tab_name=Éditeur 3D
 
+## Canvas
+program_3d_edit.canvas.please_wait=Veuillez attendre pendant que le moteur de rendu charge
+program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Bedrock
+program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Java
+program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Impossible de télécharger le dernier pack de ressources Java.\nVérifiez votre connexion internet et relancez Amulet.\nRegardez la console pour plus de détails.
+program_3d_edit.canvas.loading_resource_packs=Chargement des packs de ressources
+program_3d_edit.canvas.creating_texture_atlas=Création de l'atlas de texture
+program_3d_edit.canvas.setting_up_renderer=Préparation du moteur de rendu
+
+## Barre de menu
+program_3d_edit.menu_bar.file.save=&Sauvegarder
+program_3d_edit.menu_bar.edit.menu_name=&Editer
+program_3d_edit.menu_bar.edit.undo=Annuler
+program_3d_edit.menu_bar.edit.redo=Rétablir
+program_3d_edit.menu_bar.edit.cut=Couper
+program_3d_edit.menu_bar.edit.copy=Copier
+program_3d_edit.menu_bar.edit.paste=Coller
+program_3d_edit.menu_bar.edit.delete=Supprimer
+program_3d_edit.menu_bar.edit.goto=Se déplacer
+program_3d_edit.menu_bar.edit.select_all=Tout sélectionner
+program_3d_edit.menu_bar.options.controls=Contrôles...
+program_3d_edit.menu_bar.options.options=Options...
+program_3d_edit.menu_bar.help.controls=Contrôles
+
+## Outil de sélection
 program_3d_edit.select_tool.delete_button=Supprimer
 program_3d_edit.select_tool.delete_button_tooltip=Supprime les blocs dans la région sélectionnée.
 program_3d_edit.select_tool.copy_button=Copier
@@ -65,7 +128,6 @@ program_3d_edit.select_tool.scroll_point_z1_tooltip=Définit la coordonnée z du
 program_3d_edit.select_tool.scroll_point_x2_tooltip=Définit la coordonnée x du coin bleu de la zone de sélection active. Tapez une valeur, utilisez les flèches, ou scrollez en survolant le champ avec la souris.
 program_3d_edit.select_tool.scroll_point_y2_tooltip=Définit la coordonnée y du coin bleu de la zone de sélection active. Tapez une valeur, utilisez les flèches, ou scrollez en survolant le champ avec la souris.
 program_3d_edit.select_tool.scroll_point_z2_tooltip=Définit la coordonnée z du coin bleu de la zone de sélection active. Tapez une valeur, utilisez les flèches, ou scrollez en survolant le champ avec la souris.
-
 program_3d_edit.select_tool.box_size_selector_fstring=dx={x},dy={y},dz={z}
 program_3d_edit.select_tool.box_size_selector_tooltip=La taille de la zone de sélection active, suivant la notation de Minecraft.
 program_3d_edit.select_tool.box_size_tooltip=La taille de la zone de sélection active, en blocs.
@@ -76,6 +138,7 @@ program_3d_edit.select_tool.button_point2_tooltip=Restez appuyé sur ce bouton e
 program_3d_edit.select_tool.button_selection_box=Déplacer la zone de sélection
 program_3d_edit.select_tool.button_selection_box_tooltip=Restez appuyé sur ce bouton et utilisez les contrôles de déplacement pour déplacer la zone de sélection active.
 
+## Outil coller
 program_3d_edit.paste_tool.location_label=Position
 program_3d_edit.paste_tool.location_x_label=x
 program_3d_edit.paste_tool.location_x_tooltip=La position x où le centre du modèle sera placé. Tapez une valeur, utilisez les flèches, ou scrollez en survolant le champ avec la souris.
@@ -115,6 +178,7 @@ program_3d_edit.paste_tool.confirm_label=Confirmer
 program_3d_edit.paste_tool.confirm_tooltip=Cliquez pour coller le modèle dans le monde avec la position, la rotation, l'échelle, et les options spécifiées.
 program_3d_edit.paste_tool.zero_scale_message=L'échelle vaut 0 sur au moins un des axes. Rien n'a été collé.
 
+## Outil chunk (tronçon)
 program_3d_edit.chunk_tool.min_y=Min Y
 program_3d_edit.chunk_tool.min_y_tooltip=La coordonnée y minimum à afficher dans la vue du dessus. Peut être utilisée pour voir une tranche du monde et aider à visualiser le Nether ou les grottes.
 program_3d_edit.chunk_tool.max_y=Max Y
@@ -124,6 +188,7 @@ program_3d_edit.chunk_tool.delete_chunks_tooltip=Supprime les chunks (tronçons)
 program_3d_edit.chunk_tool.prune_chunks=Rogner les chunks
 program_3d_edit.chunk_tool.prune_chunks_tooltip=Supprime les chunks (tronçons) qui ne sont pas sélectionnés. Cela supprimera les chunks et toutes les données qu'ils contiennent. La prochaine fois que vous chargerez cette zone en jeu, de nouveaux chunks seront créés.
 
+## Fenêtre de déplacement de la caméra
 program_3d_edit.goto_ui.title=Déplacement de la caméra
 program_3d_edit.goto_ui.x_label=x :
 program_3d_edit.goto_ui.x_label_tooltip=La coordonnée x de la caméra. Tapez une coordonnée pour vous y déplacer. Ctrl + C pour copier la coordonnée. Ctrl + V pour coller.
@@ -133,25 +198,3 @@ program_3d_edit.goto_ui.z_label=z :
 program_3d_edit.goto_ui.z_label_tooltip=La coordonnée z de la caméra. Tapez une coordonnée pour vous y déplacer. Ctrl + C pour copier la coordonnée. Ctrl + V pour coller.
 program_3d_edit.goto_ui.copy_button_tooltip=Copier les coordonnées x, y et z dans le presse-papiers sous le format suivant : "0.0 0.0 0.0" (x, y et z respectivement).
 program_3d_edit.goto_ui.paste_button_tooltip=Coller des coordonnées précédemment copiées dans les champs correspondants. Les coordonnées copiées doivent être constituées de trois nombres séparés par des espaces ou des virgules.
-
-program_3d_edit.canvas.please_wait=Veuillez attendre pendant que le moteur de rendu charge
-program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Bedrock
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Java
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Impossible de télécharger le dernier pack de ressources Java.\nVérifiez votre connexion internet et relancez Amulet.\nRegardez la console pour plus de détails.
-program_3d_edit.canvas.loading_resource_packs=Chargement des packs de ressources
-program_3d_edit.canvas.creating_texture_atlas=Création de l'atlas de texture
-program_3d_edit.canvas.setting_up_renderer=Préparation du moteur de rendu
-
-program_3d_edit.menu_bar.file.save=&Sauvegarder
-program_3d_edit.menu_bar.edit.menu_name=&Editer
-program_3d_edit.menu_bar.edit.undo=Annuler
-program_3d_edit.menu_bar.edit.redo=Rétablir
-program_3d_edit.menu_bar.edit.cut=Couper
-program_3d_edit.menu_bar.edit.copy=Copier
-program_3d_edit.menu_bar.edit.paste=Coller
-program_3d_edit.menu_bar.edit.delete=Supprimer
-program_3d_edit.menu_bar.edit.goto=Se déplacer
-program_3d_edit.menu_bar.edit.select_all=Tout sélectionner
-program_3d_edit.menu_bar.options.controls=Contrôles...
-program_3d_edit.menu_bar.options.options=Options...
-program_3d_edit.menu_bar.help.controls=Contrôles

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -20,7 +20,8 @@ class LangTestCase(unittest.TestCase):
                 unique_ids = set()
                 for line_number, line in enumerate(f.readlines()):
                     line_number += 1
-                    if line.strip() and not line.startswith("#"):
+                    strip_line = line.strip()
+                    if strip_line and not strip_line.startswith("#"):
                         split_line = line.split("=", 1)
                         self.assertEqual(
                             len(split_line),


### PR DESCRIPTION
I added comments support for lang files and updated the `test_lang.py`.

Basically it allows comments lines to be written by starting them with the `#` symbol.
It also allows leading spaces before the `#` symbol, which probably won't be useful but made sense since leading spaces were already supported for normal lines.

Anyway, the purpose of this is to help contributors to better define sections in their own language (namespaces identifiers are self-speaking but they are in english). It also allows us to write notes, instructions, and info about some specific features which translators might not know (I'm thinking of the `&` in the menubar translations for example).

_Black has been used, `test_lang.py` has been ran successfully._