### PR TITLE
Catch errors and display them to the user if a sub-program failed to load

### DIFF
--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -82,7 +82,7 @@ class WorldPageUI(wx.Notebook, BasePageUI):
             raise e
         self.world_name = self.world.level_wrapper.level_name
         self._extensions: List[BaseProgram] = []
-        self._last_extension: int = -1
+        self._active_extension: int = -1
         self._load_extensions()
         self.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._page_change)
 
@@ -127,15 +127,40 @@ class WorldPageUI(wx.Notebook, BasePageUI):
 
     def _page_change(self, _):
         """Method to fire when the page is changed"""
-        if self.GetSelection() != self._last_extension:
-            self._extensions[self._last_extension].disable()
+        if self.GetSelection() != self._active_extension:
+            self._enable_active()
+
+    def _disable_active(self):
+        if self._active_extension >= 0:
+            try:
+                self._extensions[self._active_extension].disable()
+            except Exception as e:
+                log.critical(traceback.format_exc())
+            finally:
+                self._active_extension = -1
+
+    def _enable_active(self):
+        self._disable_active()
+        try:
             self._extensions[self.GetSelection()].enable()
             self.GetGrandParent().create_menu()
-            self._last_extension = self.GetSelection()
+        except Exception as e:
+            log.critical(traceback.format_exc())
+            wx.MessageDialog(
+                self,
+                f"Exception loading sub-program: {e}\nSee the console for more details",
+                style=wx.OK,
+            ).ShowModal()
+            self._extensions.pop(self.GetSelection())
+            self._active_extension = -1
+            self.DeletePage(self.GetSelection())
+        else:
+            self._active_extension = self.GetSelection()
 
     def disable(self):
-        self._extensions[self.GetSelection()].disable()
+        """Disable all containers in the world page"""
+        self._disable_active()
 
     def enable(self):
-        self._extensions[self.GetSelection()].enable()
-        self.GetGrandParent().create_menu()
+        """Enable the world page"""
+        self._enable_active()

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -74,10 +74,15 @@ class BaseEditCanvas(EventCanvas):
         self._mouse.set_middle()
 
         # load the resource packs
-        os.makedirs("resource_packs", exist_ok=True)
-        if not os.path.isfile("resource_packs/readme.txt"):
-            with open("resource_packs/readme.txt", "w") as f:
-                f.write("Put the Java resource pack you want loaded in here.")
+        try:
+            os.makedirs("resource_packs", exist_ok=True)
+            if not os.path.isfile("resource_packs/readme.txt"):
+                with open("resource_packs/readme.txt", "w") as f:
+                    f.write("Put the Java resource pack you want loaded in here.")
+        except PermissionError:
+            raise PermissionError(
+                "Amulet is not able to write to the install directory. Try moving Amulet to somewhere else on your computer."
+            )
 
         self._renderer: Optional[Renderer] = None
 

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -79,10 +79,10 @@ class BaseEditCanvas(EventCanvas):
             if not os.path.isfile("resource_packs/readme.txt"):
                 with open("resource_packs/readme.txt", "w") as f:
                     f.write("Put the Java resource pack you want loaded in here.")
-        except PermissionError:
+        except PermissionError as e:
             raise PermissionError(
                 "Amulet is not able to write to the install directory. Try moving Amulet to somewhere else on your computer."
-            )
+            ) from e
 
         self._renderer: Optional[Renderer] = None
 


### PR DESCRIPTION
fixes #308 
Previously if there was an error while enabling or disabling a sub-program there would be a silent error.
This shows that error to the user via a dialog so that they are aware of it.
Once they click okay the sub-program will be destroyed.