### PR TITLE
Added a warning dialog about installing certificates on macOS

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -170,8 +170,12 @@ class AmuletUI(wx.Frame):
                 log.error(f"Could not find a loader for this world.\n{e}")
                 wx.MessageBox(f"{lang.get('select_world.no_loader_found')}\n{e}")
             except Exception as e:
-                log.error(f"Error loading world.\n{e}\n{traceback.format_exc()}")
-                wx.MessageBox(f"{lang.get('select_world.loading_world_failed')}\n{e}")
+                log.error(lang.get("select_world.loading_world_failed"), exc_info=True)
+                wx.MessageBox(
+                    f"{lang.get('select_world.loading_world_failed')}\n"
+                    f"{e}\n"
+                    f"{lang.get('shared.check_console')}"
+                )
             else:
                 self._open_worlds[path] = world
                 self._add_world_tab(world, world.world_name)

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -67,7 +67,7 @@ select_world.open_world_dialogue=Select a Minecraft world directory
 select_world.select_directory_failed=Failed to open directory!
 select_world.recent_worlds=Recently Opened Worlds
 select_world.no_loader_found=Could not find a loader for this world.
-select_world.loading_world_failed=Error loading world. Check the console for more details.
+select_world.loading_world_failed=Error loading world.
 
 # About
 ## The default program when a world is opened

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -23,7 +23,8 @@
 ## Example: "There are {n} changes" translates to "There are 2 changes" in the UI
 ## This pattern must stay in the translated entries for them to work properly
 
-
+# Shared strings
+shared.check_console=Check the console for more details.
 
 # App
 app.world_still_used=A world is still being used. Please close it first
@@ -96,7 +97,9 @@ program_3d_edit.tab_name=3D Editor
 program_3d_edit.canvas.please_wait=Please wait while the renderer loads
 program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Downloading Bedrock vanilla resource pack
 program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Downloading Java vanilla resource pack
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Failed to download the latest Java resource pack.\nCheck your internet connection and restart Amulet.\nCheck the console for more details.
+program_3d_edit.canvas.java_rp_failed=Failed to download the latest Java resource pack.
+program_3d_edit.canvas.java_rp_failed_default=Check your internet connection and restart Amulet.
+program_3d_edit.canvas.java_rp_failed_mac_certificates=The certificates to access the internet were not installed.\nRun the "Install Certificates.command" program that can be found in "Applications/Python 3.x".
 program_3d_edit.canvas.loading_resource_packs=Loading resource packs
 program_3d_edit.canvas.creating_texture_atlas=Creating texture atlas
 program_3d_edit.canvas.setting_up_renderer=Setting up renderer

--- a/amulet_map_editor/lang/fr.lang
+++ b/amulet_map_editor/lang/fr.lang
@@ -67,7 +67,7 @@ select_world.open_world_dialogue=Sélectionnez un dossier de monde Minecraft
 select_world.select_directory_failed=Impossible d'ouvrir ce dossier !
 select_world.recent_worlds=Mondes récents
 select_world.no_loader_found=Aucun loader n'a été trouvé pour charger ce monde.
-select_world.loading_world_failed=Erreur lors du chargement du monde. Regardez la console pour plus de détails.
+select_world.loading_world_failed=Erreur lors du chargement du monde.
 
 # À propos
 ## Le programme par défaut lorsqu'on ouvre un monde

--- a/amulet_map_editor/lang/fr.lang
+++ b/amulet_map_editor/lang/fr.lang
@@ -23,7 +23,8 @@
 ## Exemple: "Il y a {n} modifications" sera traduit par "Il y a 2 modifications" dans le UI
 ## Ce pattern doit être conservé dans les entrées traduites pour qu'elles puissent fonctionner correctement
 
-
+# Shared strings
+shared.check_console=Regardez la console pour plus de détails.
 
 # Application
 app.world_still_used=Un monde est toujours en cours d'utilisation. Veuillez d'abord le fermer.
@@ -96,7 +97,8 @@ program_3d_edit.tab_name=Éditeur 3D
 program_3d_edit.canvas.please_wait=Veuillez attendre pendant que le moteur de rendu charge
 program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Bedrock
 program_3d_edit.canvas.downloading_java_vanilla_resource_pack=Téléchargement du pack de ressources vanilla Java
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=Impossible de télécharger le dernier pack de ressources Java.\nVérifiez votre connexion internet et relancez Amulet.\nRegardez la console pour plus de détails.
+program_3d_edit.canvas.java_rp_failed=Impossible de télécharger le dernier pack de ressources Java.
+program_3d_edit.canvas.java_rp_failed_default=Vérifiez votre connexion internet et relancez Amulet.
 program_3d_edit.canvas.loading_resource_packs=Chargement des packs de ressources
 program_3d_edit.canvas.creating_texture_atlas=Création de l'atlas de texture
 program_3d_edit.canvas.setting_up_renderer=Préparation du moteur de rendu

--- a/amulet_map_editor/lang/zh_CN.lang
+++ b/amulet_map_editor/lang/zh_CN.lang
@@ -1,3 +1,6 @@
+# Shared strings
+shared.check_console=查看控制台以获取更多信息.
+
 app.world_still_used=有一个世界仍在使用当中. 请先关闭它
 
 world.java_platform=Java版
@@ -137,7 +140,8 @@ program_3d_edit.goto_ui.paste_button_tooltip=将先前复制的坐标粘贴到�
 program_3d_edit.canvas.please_wait=渲染器正在初始化, 请稍作等待
 program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=正在下载基岩版纯净资源包
 program_3d_edit.canvas.downloading_java_vanilla_resource_pack=正在下载Java版纯净资源包
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=无法下载最新版本的Java版纯净资源包.\n请检查你的网络连接或重启Amulet.\n查看控制台以获取更多信息.
+program_3d_edit.canvas.java_rp_failed=无法下载最新版本的Java版纯净资源包.
+program_3d_edit.canvas.java_rp_failed_default=请检查你的网络连接或重启Amulet.
 program_3d_edit.canvas.loading_resource_packs=正在加载资源包
 program_3d_edit.canvas.creating_texture_atlas=正在创建纹理
 program_3d_edit.canvas.setting_up_renderer=正在设置渲染器

--- a/amulet_map_editor/lang/zh_CN.lang
+++ b/amulet_map_editor/lang/zh_CN.lang
@@ -13,7 +13,7 @@ select_world.open_world_dialogue=选择一个Minecraft存档目录
 select_world.select_directory_failed=无法打开目录!
 select_world.recent_worlds=最近打开的世界
 select_world.no_loader_found=无法为该世界找到一个加载器.
-select_world.loading_world_failed=世界加载失败. 请检查控制台输出以获取更多信息.
+select_world.loading_world_failed=世界加载失败.
 
 main_menu.tab_name=主菜单
 main_menu.open_world=打开世界

--- a/amulet_map_editor/lang/zh_TW.lang
+++ b/amulet_map_editor/lang/zh_TW.lang
@@ -13,7 +13,7 @@ select_world.open_world_dialogue=選擇一個Minecraft存檔目錄
 select_world.select_directory_failed=無法打開目錄!
 select_world.recent_worlds=最近打開的世界
 select_world.no_loader_found=無法為該世界找到一個加載器.
-select_world.loading_world_failed=世界加載失敗. 請檢查控制臺輸出以獲取更多信息.
+select_world.loading_world_failed=世界加載失敗.
 
 main_menu.tab_name=主菜單
 main_menu.open_world=打開世界

--- a/amulet_map_editor/lang/zh_TW.lang
+++ b/amulet_map_editor/lang/zh_TW.lang
@@ -1,3 +1,6 @@
+# Shared strings
+shared.check_console=查看控制臺以獲取更多信息.
+
 app.world_still_used=有一個世界仍在使用當中. 請先關閉它
 
 world.java_platform=Java版
@@ -137,7 +140,8 @@ program_3d_edit.goto_ui.paste_button_tooltip=將先前復制的坐標粘貼到�
 program_3d_edit.canvas.please_wait=渲染器正在初始化, 請稍作等待
 program_3d_edit.canvas.downloading_bedrock_vanilla_resource_pack=正在下載基巖版純凈資源包
 program_3d_edit.canvas.downloading_java_vanilla_resource_pack=正在下載Java版純凈資源包
-program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed=無法下載最新版本的Java版純凈資源包.\n請檢查你的網絡連接或重啟Amulet.\n查看控制臺以獲取更多信息.
+program_3d_edit.canvas.java_rp_failed=無法下載最新版本的Java版純凈資源包.
+program_3d_edit.canvas.java_rp_failed_default=請檢查你的網絡連接或重啟Amulet.
 program_3d_edit.canvas.loading_resource_packs=正在加載資源包
 program_3d_edit.canvas.creating_texture_atlas=正在創建紋理
 program_3d_edit.canvas.setting_up_renderer=正在設置渲染器

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -156,7 +156,9 @@ class BaseEditCanvas(EventCanvas):
                 packs.append(e.value)
             except Exception as e:
                 if sys.platform == "darwin" and "CERTIFICATE_VERIFY_FAILED" in str(e):
-                    msg = lang.get("program_3d_edit.canvas.java_rp_failed_mac_certificates")
+                    msg = lang.get(
+                        "program_3d_edit.canvas.java_rp_failed_mac_certificates"
+                    )
                 else:
                     msg = lang.get("program_3d_edit.canvas.java_rp_failed_default")
                 log.error(

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -7,6 +7,7 @@ from OpenGL.GL import (
 import os
 from typing import Optional, Generator
 import weakref
+import sys
 
 from minecraft_model_reader.api.resource_pack.java.download_resources import (
     get_java_vanilla_latest_iter,
@@ -154,12 +155,19 @@ class BaseEditCanvas(EventCanvas):
             except StopIteration as e:
                 packs.append(e.value)
             except Exception as e:
+                if sys.platform == "darwin" and "CERTIFICATE_VERIFY_FAILED" in str(e):
+                    msg = lang.get("program_3d_edit.canvas.java_rp_failed_mac_certificates")
+                else:
+                    msg = lang.get("program_3d_edit.canvas.java_rp_failed_default")
                 log.error(
-                    str(e),
+                    msg,
                     exc_info=True,
                 )
                 wx.MessageBox(
-                    f"{lang.get('program_3d_edit.canvas.downloading_java_vanilla_resource_pack_failed')}\n{e}"
+                    f"{lang.get('program_3d_edit.canvas.java_rp_failed')}\n"
+                    f"{msg}\n"
+                    f"{e}\n"
+                    f"{lang.get('shared.check_console')}"
                 )
 
             yield 0.5, lang.get("program_3d_edit.canvas.loading_resource_packs")


### PR DESCRIPTION
When running from source on macOS you need to run the install certificates file.
This is mentioned in the installer but a number of users has missed this and the error that is given is a little cryptic.
Hopefully this should make it more clear to those users.
Split up the lang entries to make it easier to add more errors