### PR TITLE
Added a loading bar when closing worlds

### DIFF
--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -123,7 +123,26 @@ class WorldPageUI(wx.Notebook, BasePageUI):
         Check is_closeable before running this"""
         for ext in self._extensions:
             ext.close()
+        dialog = None
+
+        def init_dialog():
+            nonlocal dialog
+            dialog = wx.ProgressDialog(
+                "Closing World",
+                "Please be patient. This may take a little while.",
+                maximum=100,
+                parent=self,
+                style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
+            )
+            dialog.Fit()
+            dialog.Update(99)
+
+        timer = wx.CallLater(200, init_dialog)
         self.world.close()
+        if dialog is None:
+            timer.Stop()
+        else:
+            dialog.Update(100)
 
     def _page_change(self, _):
         """Method to fire when the page is changed"""

--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -123,26 +123,16 @@ class WorldPageUI(wx.Notebook, BasePageUI):
         Check is_closeable before running this"""
         for ext in self._extensions:
             ext.close()
-        dialog = None
-
-        def init_dialog():
-            nonlocal dialog
-            dialog = wx.ProgressDialog(
-                "Closing World",
-                "Please be patient. This may take a little while.",
-                maximum=100,
-                parent=self,
-                style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
-            )
-            dialog.Fit()
-            dialog.Update(99)
-
-        timer = wx.CallLater(200, init_dialog)
+        dialog = wx.ProgressDialog(
+            "Closing World",
+            "Please be patient. This may take a little while.",
+            maximum=100,
+            parent=self,
+            style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
+        )
+        dialog.Fit()
         self.world.close()
-        if dialog is None:
-            timer.Stop()
-        else:
-            dialog.Update(100)
+        dialog.Update(100)
 
     def _page_change(self, _):
         """Method to fire when the page is changed"""

--- a/amulet_map_editor/api/opengl/canvas/canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/canvas.py
@@ -58,5 +58,5 @@ class BaseCanvas(glcanvas.GLCanvas):
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
-    def _close(self):
+    def close(self):
         glDeleteTextures([self._gl_texture_atlas])

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -222,9 +222,9 @@ class BaseEditCanvas(EventCanvas):
         return self.renderer.is_closeable()
 
     def close(self):
-        """Close and destroy the canvas and all contained data."""
+        """Destroy all contained data so that the window can be safely destroyed."""
         self.renderer.close()
-        super()._close()
+        super().close()
 
     @property
     def world(self) -> BaseLevel:

--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -37,7 +37,6 @@ from amulet_map_editor.programs.edit.api.events import (
     RedoEvent,
     CreateUndoEvent,
     SaveEvent,
-    EditCloseEvent,
     PasteEvent,
     ToolChangeEvent,
     EVT_EDIT_CLOSE,
@@ -80,10 +79,10 @@ def show_loading_dialog(
             except StopIteration as e:
                 obj = e.value
     except Exception as e:
-        dialog.Destroy()
+        dialog.Update(10_000)
         raise e
     time.sleep(max(0.2 - time.time() + t, 0))
-    dialog.Destroy()
+    dialog.Update(10_000)
     return obj
 
 
@@ -319,6 +318,3 @@ class EditCanvas(BaseEditCanvas):
         show_loading_dialog(save, "Saving world.", "Please wait.", self)
         wx.PostEvent(self, SaveEvent())
         self.renderer.enable_threads()
-
-    def close(self):
-        wx.PostEvent(self, EditCloseEvent())

--- a/amulet_map_editor/programs/edit/api/ui/file.py
+++ b/amulet_map_editor/programs/edit/api/ui/file.py
@@ -14,6 +14,7 @@ from amulet_map_editor.programs.edit.api.events import (
     EVT_PROJECTION_CHANGED,
     EVT_DIMENSION_CHANGE,
     DimensionChangeEvent,
+    EditCloseEvent,
 )
 from amulet_map_editor.api import image, lang
 from amulet_map_editor.api.opengl.camera import Projection
@@ -93,7 +94,9 @@ class FilePanel(wx.BoxSizer, EditCanvasContainer):
             canvas, bitmap=image.icon.tablericons.square_x.bitmap(20, 20)
         )
         close_button.SetToolTip(lang.get("program_3d_edit.file_ui.close_tooltip"))
-        close_button.Bind(wx.EVT_BUTTON, lambda evt: self.canvas.close())
+        close_button.Bind(
+            wx.EVT_BUTTON, lambda evt: wx.PostEvent(self.canvas, EditCloseEvent())
+        )
         self.Add(close_button, 0, wx.TOP | wx.BOTTOM | wx.RIGHT, 5)
 
         self._update_buttons()


### PR DESCRIPTION
Some worlds take a while to close (particularly Bedrock which runs the compaction logic on close) and the program will hang while this is happening.
Added a dialog to reassure the user that something is happening and the program has not crashed.
This should fix #321 
Fixed a recursion issue when closing from the button in the canvas.
Fixed a crash when closing from the button in the canvas and saving.