### PR TITLE
Added an error UI that also displays the traceback

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -5,6 +5,7 @@ import traceback
 
 from amulet.api.errors import LoaderNoneMatched
 from amulet_map_editor.api.wx.ui.select_world import WorldSelectDialog
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor import __version__, lang, log
 from amulet_map_editor.api.framework.pages import WorldPageUI
 from .pages import AmuletMainMenu, BasePageUI
@@ -171,11 +172,14 @@ class AmuletUI(wx.Frame):
                 wx.MessageBox(f"{lang.get('select_world.no_loader_found')}\n{e}")
             except Exception as e:
                 log.error(lang.get("select_world.loading_world_failed"), exc_info=True)
-                wx.MessageBox(
-                    f"{lang.get('select_world.loading_world_failed')}\n"
-                    f"{e}\n"
-                    f"{lang.get('shared.check_console')}"
+                dialog = TracebackDialog(
+                    self,
+                    lang.get("select_world.loading_world_failed"),
+                    str(e),
+                    traceback.format_exc(),
                 )
+                dialog.ShowModal()
+                dialog.Destroy()
             else:
                 self._open_worlds[path] = world
                 self._add_world_tab(world, world.world_name)

--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -13,6 +13,7 @@ from amulet_map_editor import programs, log, lang
 from amulet_map_editor.api.datatypes import MenuData
 from amulet_map_editor.api.framework.pages import BasePageUI
 from amulet_map_editor.api.framework.programs import BaseProgram, AboutProgram
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 
 _extensions: List[Tuple[str, Type[BaseProgram]]] = []
 _fixed_extensions: List[Tuple[str, Type[BaseProgram]]] = [
@@ -155,11 +156,11 @@ class WorldPageUI(wx.Notebook, BasePageUI):
             self.GetGrandParent().create_menu()
         except Exception as e:
             log.critical(traceback.format_exc())
-            wx.MessageDialog(
-                self,
-                f"Exception loading sub-program: {e}\nSee the console for more details",
-                style=wx.OK,
-            ).ShowModal()
+            dialog = TracebackDialog(
+                self, "Exception loading sub-program", str(e), traceback.format_exc()
+            )
+            dialog.ShowModal()
+            dialog.Destroy()
             self._extensions.pop(self.GetSelection())
             self._active_extension = -1
             self.DeletePage(self.GetSelection())

--- a/amulet_map_editor/api/wx/ui/traceback_dialog.py
+++ b/amulet_map_editor/api/wx/ui/traceback_dialog.py
@@ -1,0 +1,94 @@
+from typing import Optional
+import wx
+import wx.lib.expando
+from amulet_map_editor.api import image
+
+
+class TracebackDialog(wx.Dialog):
+    def __init__(
+        self,
+        parent: Optional[wx.Window],
+        title: str,
+        error: str,
+        traceback: str,
+        **kwargs,
+    ):
+        kwargs["style"] = (
+            kwargs.get("style", 0) | wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
+        )
+        wx.Dialog.__init__(self, parent, **kwargs)
+        self.SetTitle(title)
+
+        self._error = error
+        self._traceback = traceback
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(main_sizer)
+
+        error_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        main_sizer.Add(error_sizer, 0, wx.EXPAND | wx.ALL, 5)
+
+        bitmap_1 = wx.StaticBitmap(
+            self, bitmap=image.icon.tablericons.alert_circle.bitmap(32, 32)
+        )
+        error_sizer.Add(bitmap_1, 0, 0, 0)
+
+        error_text = wx.StaticText(self, wx.ID_ANY, error)
+        error_sizer.Add(error_text, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        traceback_text = wx.lib.expando.ExpandoTextCtrl(
+            self,
+            wx.ID_ANY,
+            traceback,
+            style=wx.TE_MULTILINE | wx.TE_READONLY,
+            size=(800, -1),
+        )
+        main_sizer.Add(traceback_text, 1, wx.EXPAND, 0)
+
+        button_sizer = wx.StdDialogButtonSizer()
+        main_sizer.Add(button_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 4)
+
+        copy_button = wx.Button(self, wx.ID_ANY, "Copy Error")
+        copy_button.Bind(wx.EVT_BUTTON, self._on_copy_error)
+        button_sizer.Add(copy_button, 0, 0, 0)
+
+        button_ok = wx.Button(self, wx.ID_OK, "")
+        button_ok.SetDefault()
+        button_sizer.AddButton(button_ok)
+
+        button_sizer.Realize()
+
+        main_sizer.Fit(self)
+
+        self.SetAffirmativeId(button_ok.GetId())
+
+        self.Fit()
+        self.Layout()
+
+    def _on_copy_error(self, evt):
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(
+                wx.TextDataObject(f"{self._error}\n{self._traceback}")
+            )
+            wx.TheClipboard.Close()
+
+
+class MyApp(wx.App):
+    def OnInit(self):
+        import traceback as traceback_
+
+        try:
+            raise Exception("Exception message")
+        except Exception as e:
+            err = str(e)
+            tb = traceback_.format_exc()
+        self.dialog = TracebackDialog(None, "title", err, tb)
+        self.SetTopWindow(self.dialog)
+        self.dialog.ShowModal()
+        self.dialog.Destroy()
+        return True
+
+
+if __name__ == "__main__":
+    app = MyApp(0)
+    app.MainLoop()

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -42,6 +42,7 @@ import amulet_map_editor.programs.edit as amulet_edit
 from amulet_map_editor.api.opengl.camera import ControllableCamera
 from amulet_map_editor.api.wx.util.button_input import ButtonInput
 from amulet_map_editor.api.wx.util.mouse_movement import MouseMovement
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from ..renderer import Renderer
 
 from amulet.api.level import BaseLevel
@@ -170,12 +171,14 @@ class BaseEditCanvas(EventCanvas):
                     msg,
                     exc_info=True,
                 )
-                wx.MessageBox(
-                    f"{lang.get('program_3d_edit.canvas.java_rp_failed')}\n"
-                    f"{msg}\n"
-                    f"{e}\n"
-                    f"{lang.get('shared.check_console')}"
+                dialog = TracebackDialog(
+                    self,
+                    lang.get("program_3d_edit.canvas.java_rp_failed"),
+                    f"{msg}\n{e}",
+                    traceback.format_exc(),
                 )
+                dialog.ShowModal()
+                dialog.Destroy()
 
             yield 0.5, lang.get("program_3d_edit.canvas.loading_resource_packs")
             packs += [pack for pack in user_packs if isinstance(pack, JavaResourcePack)]

--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -19,6 +19,7 @@ from amulet.api.structure import structure_cache
 from amulet.api.level import BaseLevel
 
 from amulet_map_editor import CONFIG, log
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor.programs.edit.api.ui.goto import show_goto
 from amulet_map_editor.programs.edit.api.ui.tool_manager import ToolManagerSizer
 from amulet_map_editor.programs.edit.api.operations import (
@@ -192,14 +193,17 @@ class EditCanvas(BaseEditCanvas):
             self.world.restore_last_undo_point()
             err = e
         except Exception as e:
-            self.world.restore_last_undo_point()
             log.error(traceback.format_exc())
-            wx.MessageDialog(
+            dialog = TracebackDialog(
                 self,
-                f"Exception running operation: {e}\nSee the console for more details",
-                style=wx.OK,
-            ).ShowModal()
+                "Exception while running operation",
+                str(e),
+                traceback.format_exc(),
+            )
+            dialog.ShowModal()
+            dialog.Destroy()
             err = e
+            self.world.restore_last_undo_point()
 
         self.renderer.enable_threads()
         self.renderer.render_world.rebuild_changed()

--- a/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
@@ -9,8 +9,9 @@ import os
 
 import amulet
 from amulet.api.errors import LoaderNoneMatched
-from amulet_map_editor import log
 
+from amulet_map_editor import log
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor.api.opengl.camera import Projection
 from .base_tool_ui import BaseToolUI
 from amulet_map_editor.programs.edit.api.events import EVT_DRAW
@@ -65,15 +66,19 @@ class DefaultBaseToolUI(BaseToolUI):
                 try:
                     level = amulet.load_level(pathname)
                 except LoaderNoneMatched:
-                    wx.MessageBox(f"Could not find a matching loader for {pathname}.")
-                    log.error(f"Could not find a matching loader for {pathname}.")
+                    msg = f"Could not find a matching loader for {pathname}."
+                    wx.MessageBox(msg)
+                    log.error(msg)
                 except Exception as e:
-                    log.error(
-                        f"Could not open {pathname}. Check the console for more details.\n{traceback.format_exc()}"
+                    log.error(f"Could not open {pathname}.", exc_info=True)
+                    dialog = TracebackDialog(
+                        self.canvas,
+                        f"Could not open {pathname}.",
+                        str(e),
+                        traceback.format_exc(),
                     )
-                    wx.MessageBox(
-                        f"Could not open {pathname}. Check the console for more details.\n{e}"
-                    )
+                    dialog.ShowModal()
+                    dialog.Destroy()
                 else:
                     self.canvas.paste(level, level.dimensions[0])
         evt.Skip()

--- a/amulet_map_editor/programs/edit/plugins/tools/import_tool.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/import_tool.py
@@ -2,11 +2,14 @@ import wx
 from typing import TYPE_CHECKING
 import traceback
 
-from amulet_map_editor import log
-from amulet_map_editor.programs.edit.api.ui.tool import DefaultBaseToolUI
-from amulet_map_editor.programs.edit.api.behaviour import StaticSelectionBehaviour
 import amulet
 from amulet.api.errors import LoaderNoneMatched
+
+from amulet_map_editor import log
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
+from amulet_map_editor.programs.edit.api.ui.tool import DefaultBaseToolUI
+from amulet_map_editor.programs.edit.api.behaviour import StaticSelectionBehaviour
+
 
 if TYPE_CHECKING:
     from amulet_map_editor.programs.edit.api.canvas import EditCanvas
@@ -62,14 +65,18 @@ class ImportTool(wx.BoxSizer, DefaultBaseToolUI):
         try:
             level = amulet.load_level(pathname)
         except LoaderNoneMatched:
-            wx.MessageBox(f"Could not find a matching loader for {pathname}.")
-            log.error(f"Could not find a matching loader for {pathname}.")
+            msg = f"Could not find a matching loader for {pathname}."
+            log.error(msg)
+            wx.MessageBox(msg)
         except Exception as e:
-            log.error(
-                f"Could not open {pathname}. Check the console for more details.\n{traceback.format_exc()}"
+            log.error(f"Could not open {pathname}.", exc_info=True)
+            dialog = TracebackDialog(
+                self.canvas,
+                f"Could not open {pathname}.",
+                str(e),
+                traceback.format_exc(),
             )
-            wx.MessageBox(
-                f"Could not open {pathname}. Check the console for more details.\n{e}"
-            )
+            dialog.ShowModal()
+            dialog.Destroy()
         else:
             self.canvas.paste(level, level.dimensions[0])


### PR DESCRIPTION
A lot of users have been reporting issues and we have to ask them for the traceback because it is currently hidden in the console.
This UI displays the traceback within the UI that is shown to the user with the ability to copy the traceback to the clipboard.
This should make it easier for users to report issues.
![image](https://user-images.githubusercontent.com/11940194/123238221-3871bd00-d4d6-11eb-96e4-01d8a672e124.png)
