### PR TITLE
Fix opengl on macOS

### DIFF
--- a/amulet_map_editor/api/opengl/__init__.py
+++ b/amulet_map_editor/api/opengl/__init__.py
@@ -1,3 +1,25 @@
 from .context_manager import ContextManager
 from .drawable import Drawable
 from .thread_generator import ThreadedObject, ThreadedObjectContainer
+
+
+def check_opengl(checked=False):
+    try:
+        import OpenGL.GL
+    except ImportError as e:
+        import os
+        import ctypes.util
+
+        uname = os.uname()
+        if uname[0] == "Darwin" and uname[2] >= "20." and not checked:
+            real_find_library = ctypes.util.find_library
+
+            def find_library(name):
+                if name in {"OpenGL", "GLUT"}:  # add more names here if necessary
+                    return f"/System/Library/Frameworks/{name}.framework/{name}"
+                return real_find_library(name)
+
+            ctypes.util.find_library = find_library
+            check_opengl(True)
+        else:
+            raise e

--- a/amulet_map_editor/programs/edit/__init__.py
+++ b/amulet_map_editor/programs/edit/__init__.py
@@ -1,7 +1,8 @@
 from amulet_map_editor import lang
-from amulet_map_editor.programs.edit.edit import EditExtension
 from amulet_map_editor.api.opengl import check_opengl
 
 check_opengl()
+
+from amulet_map_editor.programs.edit.edit import EditExtension
 
 export = {"name": lang.get("program_3d_edit.tab_name"), "ui": EditExtension}

--- a/amulet_map_editor/programs/edit/__init__.py
+++ b/amulet_map_editor/programs/edit/__init__.py
@@ -1,4 +1,7 @@
 from amulet_map_editor import lang
 from amulet_map_editor.programs.edit.edit import EditExtension
+from amulet_map_editor.api.opengl import check_opengl
+
+check_opengl()
 
 export = {"name": lang.get("program_3d_edit.tab_name"), "ui": EditExtension}


### PR DESCRIPTION
macOS changed some things with opengl in one of the newer releases which means that opengl cannot be imported.
This should patch the loading logic to find the new location if opengl failed to load.
This should fix #226 