### PR TITLE
Implemented a Find Block operation

### DIFF
--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/find_block.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/find_block.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import numpy
+import wx
+
+from amulet_map_editor.api.wx.ui.block_select import BlockDefine
+from amulet_map_editor.api.wx.ui.simple import SimpleDialog
+from amulet_map_editor.programs.edit.api.operations import SimpleOperationPanel
+
+if TYPE_CHECKING:
+    from amulet.api.level import BaseLevel
+    from amulet.api.selection import SelectionGroup
+    from amulet.api.data_types import Dimension
+
+
+class ResultDialog(SimpleDialog):
+    def __init__(self, parent, block_location_info):
+        super(ResultDialog, self).__init__(parent, "Block Locations")
+
+        self.sizer.Add(
+            wx.StaticText(
+                self, label=f"Block finding results:", style=wx.ALIGN_CENTRE_HORIZONTAL
+            ),
+            0,
+            wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL,
+            5,
+        )
+
+        tree = wx.TreeCtrl(self, style=wx.TR_DEFAULT_STYLE | wx.TR_HIDE_ROOT)
+        _root = tree.AddRoot("__root__")
+
+        for block in block_location_info:
+            block_root = tree.AppendItem(
+                _root, f"{block} - {len(block_location_info[block])} locations"
+            )
+            for coordinates in block_location_info[block]:
+                tree.AppendItem(block_root, str(coordinates))
+
+        self.sizer.Add(tree, 1, wx.ALL | wx.EXPAND, 5)
+
+        self.Layout()
+
+
+class FindBlock(SimpleOperationPanel):
+    def __init__(self, parent, canvas, world, options_path):
+        SimpleOperationPanel.__init__(self, parent, canvas, world, options_path)
+        self.Freeze()
+
+        self._sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(self._sizer)
+
+        options = self._load_options({})
+
+        self._block_define = BlockDefine(
+            self,
+            world.translation_manager,
+            wx.VERTICAL,
+            *(
+                options.get("target_block_options", [])
+                or [world.level_wrapper.platform]
+            ),
+            show_pick_block=True,
+        )
+        self._findSubTypes = wx.CheckBox(self, label="Find All Block Substates")
+        self._findSubTypes.SetValue(options.get("find_substates", False))
+
+        # self._block_define.Bind(EVT_PICK, self._on_pick_block)
+        self._sizer.Add(self._block_define, 1, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 5)
+        self._sizer.Add(self._findSubTypes, 0, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 5)
+
+        self._add_run_button()
+
+        self.Thaw()
+
+    def _get_target_block(self):
+        return self._block_define.universal_block[0]
+
+    def _get_find_all_substates(self):
+        return self._findSubTypes.GetValue()
+
+    def disable(self):
+        self._save_options(
+            {
+                "target_block": self._get_target_block(),
+                "target_block_options": (
+                    self._block_define.platform,
+                    self._block_define.version_number,
+                    self._block_define.force_blockstate,
+                    self._block_define.namespace,
+                    self._block_define.block_name,
+                    self._block_define.properties,
+                ),
+                "find_substates": self._get_find_all_substates(),
+            }
+        )
+
+    def _find_single_blockstate(self, world, dimension, selection):
+        target = world.block_palette.get_add_block(self._get_target_block())
+
+        iter_count = len(list(world.get_chunk_slice_box(dimension, selection, False)))
+        count = 0
+
+        block_locations = []
+
+        for chunk, slices, _ in world.get_chunk_slice_box(dimension, selection, False):
+            block_selection = chunk.blocks[slices]
+            x_values, y_values, z_values = numpy.where(block_selection == target)
+            for x, y, z in zip(x_values, y_values, z_values):
+                block_locations.append(
+                    (
+                        block_selection.start_x + x,
+                        block_selection.start_y + y,
+                        block_selection.start_z + z,
+                    )
+                )
+            count += 1
+            yield count / iter_count
+
+        result = {
+            world.translation_manager.get_version(
+                world.level_wrapper.platform, world.level_wrapper.version
+            )
+            .block.from_universal(world.block_palette[target])[0]
+            .full_blockstate: block_locations
+        }
+
+        dialog = ResultDialog(self.parent, result)
+        dialog.Show()
+
+    def _find_multiple_blockstates(
+        self, world: "BaseLevel", dimension: "Dimension", selection: "SelectionGroup"
+    ):
+        blocks_to_find = {world.block_palette.get_add_block(self._get_target_block())}
+        block_translator = world.translation_manager.get_version(
+            world.level_wrapper.platform, world.level_wrapper.version
+        ).block
+        versioned_block_name = block_translator.from_universal(
+            self._get_target_block()
+        )[0].namespaced_name
+
+        # TODO: Find a better way to iterate through all permutations of the wanted blockstates
+        # Technically, this is the correct way, since if a Block's substate doesn't exist in the
+        # world, then it wouldn't be present in the block_palette and thus would be skipped
+        # but to users this may not seem straightforward since it would look like the operation
+        # is missing blockstates when the results window is shown
+        blocks_to_find = blocks_to_find.union(
+            map(
+                lambda t: t[0],
+                filter(
+                    lambda b: b[1].namespaced_name == versioned_block_name,
+                    map(
+                        lambda b: (b[0], block_translator.from_universal(b[1])[0]),
+                        world.block_palette.items(),
+                    ),
+                ),
+            )
+        )
+
+        iter_count = len(list(world.get_chunk_slice_box(dimension, selection, False)))
+        iter_count *= len(blocks_to_find)
+        count = 0
+
+        block_locations = {internal_id: [] for internal_id in blocks_to_find}
+        for internal_id in blocks_to_find:
+            for chunk, slices, _ in world.get_chunk_slice_box(
+                dimension, selection, False
+            ):
+                block_selection = chunk.blocks[slices]
+                x_values, y_values, z_values = numpy.where(
+                    block_selection == internal_id
+                )
+                for x, y, z in zip(x_values, y_values, z_values):
+                    block_locations[internal_id].append(
+                        (
+                            block_selection.start_x + x,
+                            block_selection.start_y + y,
+                            block_selection.start_z + z,
+                        )
+                    )
+                count += 1
+                yield count / iter_count
+
+        result = {
+            world.translation_manager.get_version(
+                world.level_wrapper.platform, world.level_wrapper.version
+            )
+            .block.from_universal(world.block_palette[_id])[0]
+            .full_blockstate: block_locations[_id]
+            for _id in block_locations.keys()
+        }
+
+        dialog = ResultDialog(self.parent, result)
+        dialog.Show()
+
+    def _operation(
+        self, world: "BaseLevel", dimension: "Dimension", selection: "SelectionGroup"
+    ):
+        if self._get_find_all_substates():
+            yield from self._find_multiple_blockstates(world, dimension, selection)
+        else:
+            yield from self._find_single_blockstate(world, dimension, selection)
+        """
+        blocks_to_find = [
+            world.block_palette.get_add_block(self._get_target_block()),
+        ]
+
+        if self._get_find_all_substates():
+            base_namespaced_name = self._get_target_block().namespaced_name
+            blocks_to_find.extend(
+                map(
+                    lambda t: t[0],
+                    filter(
+                        lambda b: b[1].namespaced_name == base_namespaced_name,
+                        world.block_palette.items(),
+                    ),
+                )
+            )
+
+        iter_count = len(list(world.get_chunk_slice_box(dimension, selection, False)))
+        iter_count *= len(blocks_to_find)
+        count = 0
+
+        block_locations = {internal_id: [] for internal_id in blocks_to_find}
+
+        for internal_id in blocks_to_find:
+            for chunk, slices, _ in world.get_chunk_slice_box(
+                dimension, selection, False
+            ):
+                block_selection = chunk.blocks[slices]
+                x_values, y_values, z_values = numpy.where(
+                    block_selection == internal_id
+                )
+                for x, y, z in zip(x_values, y_values, z_values):
+                    block_locations[internal_id].append(
+                        (
+                            block_selection.start_x + x,
+                            block_selection.start_y + y,
+                            block_selection.start_z + z,
+                        )
+                    )
+                count += 1
+                yield count / iter_count
+
+        result = {
+            world.translation_manager.get_version(
+                world.level_wrapper.platform, world.level_wrapper.version
+            )
+            .block.from_universal(world.block_palette[_id])[0]
+            .full_blockstate: block_locations[_id]
+            for _id in block_locations.keys()
+        }
+
+        dialog = ResultDialog(self.parent, result)
+        dialog.Show()
+        """
+
+
+export = {"name": "Find Block", "operation": FindBlock}

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/find_block.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/find_block.py
@@ -45,7 +45,7 @@ class ResultDialog(SimpleDialog):
 
     def build_results(self):
         count = 0
-        iter_count = reduce(add, map(len, self._block_location_info.values()))
+        iter_count = sum(map(len, self._block_location_info.values()))
 
         for block in self._block_location_info:
             block_root = self._tree.AppendItem(


### PR DESCRIPTION
This adds a new operation that finds a specific block (or all substates of a given block's namespaced name) and then reports the results in a tree control dialog with all of the coordinates

Example of the find block results dialog:
![find_block_results](https://user-images.githubusercontent.com/4026610/123532718-acca7d00-d6dd-11eb-8034-e4d75d3c2722.PNG)
