### PR TITLE
Switched out get_chunk_slice_box for get_coord_box

### DIFF
--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -143,7 +143,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
         original_block_matches = []
         universal_block_count = 0
 
-        iter_count = len(list(world.get_chunk_slice_box(dimension, selection)))
+        iter_count = len(list(world.get_coord_box(dimension, selection)))
         count = 0
 
         for chunk, slices, _ in world.get_chunk_slice_box(dimension, selection):

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/set_biome.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/set_biome.py
@@ -112,7 +112,7 @@ class SetBiome(SimpleOperationPanel):
     ) -> "OperationReturnType":
         mode = self._mode.GetCurrentObject()
 
-        iter_count = len(list(world.get_chunk_slice_box(dimension, selection, False)))
+        iter_count = len(list(world.get_coord_box(dimension, selection, False)))
         for count, (chunk, slices, _) in enumerate(
             world.get_chunk_slice_box(dimension, selection, False)
         ):

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
@@ -149,7 +149,7 @@ class Waterlog(wx.Panel, DefaultOperationUI):
         world = self.world
         selection = self.canvas.selection.selection_group
         dimension = self.canvas.dimension
-        iter_count = len(list(world.get_chunk_slice_box(dimension, selection, True)))
+        iter_count = len(list(world.get_coord_box(dimension, selection, True)))
         count = 0
         for chunk, slices, _ in world.get_chunk_slice_box(dimension, selection, True):
             original_blocks = chunk.blocks[slices]


### PR DESCRIPTION
The previously used method loaded all of the chunks.
This means the loading bar would stay at 0 for a little bit.
The replaced method should be quicker and the chunk loading done while the loading bar is updated.