### PR TITLE
Updated location of wx.VERSION for linux

### DIFF
--- a/amulet_map_editor/__main__.py
+++ b/amulet_map_editor/__main__.py
@@ -13,7 +13,7 @@ from amulet_map_editor.api.framework import AmuletApp
 
 
 if __name__ == "__main__":
-    if sys.platform == "linux" and wx.__version__.VERSION >= (4, 1, 1):
+    if sys.platform == "linux" and wx.VERSION >= (4, 1, 1):
         # bug 247
         os.environ["PYOPENGL_PLATFORM"] = "egl"
     try:

--- a/amulet_map_editor/__main__.py
+++ b/amulet_map_editor/__main__.py
@@ -7,7 +7,7 @@ if sys.version_info[:2] < (3, 7):
 
 import os
 import traceback
-import wx.__version__
+import wx
 from amulet_map_editor import log
 from amulet_map_editor.api.framework import AmuletApp
 


### PR DESCRIPTION
When starting on linux, amulet almost immediately crashes, returning this as part of the traceback:

        if sys.platform == "linux" and wx.__version__.VERSION >= (4, 1, 1):
    AttributeError: 'str' object has no attribute 'VERSION'

It seems that wx moved the tuple version information, which I updated to match. The proposed fix has been tested with Python 3.7 on Debian 10.1, and with Python 3.9 on a recent Debian Testing.