### PR TITLE
Moved imports in __main__ into a try except block

### DIFF
--- a/amulet_map_editor/__main__.py
+++ b/amulet_map_editor/__main__.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python3
 
-import sys
-
-if sys.version_info[:2] < (3, 7):
-    raise Exception("Must be using Python 3.7+")
-
-import os
-import traceback
-import wx
-from amulet_map_editor import log
-from amulet_map_editor.api.framework import AmuletApp
-
-
 if __name__ == "__main__":
-    if sys.platform == "linux" and wx.VERSION >= (4, 1, 1):
-        # bug 247
-        os.environ["PYOPENGL_PLATFORM"] = "egl"
     try:
-        app = AmuletApp(0)
-        app.MainLoop()
+        import sys
+
+        if sys.version_info[:2] < (3, 7):
+            raise Exception("Must be using Python 3.7+")
+
+        import os
+        import traceback
+        import wx
+        from amulet_map_editor import log
+        from amulet_map_editor.api.framework import AmuletApp
+
+        if sys.platform == "linux" and wx.VERSION >= (4, 1, 1):
+            # bug 247
+            os.environ["PYOPENGL_PLATFORM"] = "egl"
+
     except Exception as e:
-        log.critical(
-            f"Amulet Crashed. Sorry about that. Please report it to a developer if you think this is an issue. \n{traceback.format_exc()}"
-        )
+        err = f"Failed to import requirements. Check that you extracted correctly.\n{e}"
+        print(err)
+        with open("./logs/amulet_map_editor_.log") as f:
+            f.write(err)
         input("Press ENTER to continue.")
+    else:
+        try:
+            app = AmuletApp(0)
+            app.MainLoop()
+        except Exception as e:
+            log.critical(
+                f"Amulet Crashed. Sorry about that. Please report it to a developer if you think this is an issue. \n{traceback.format_exc()}"
+            )
+            input("Press ENTER to continue.")


### PR DESCRIPTION
If part of Amulet was missing, the error would happen outside the existing try except block.
This moves the imports into a try except block so that if an error does occur it can be reported correctly.
This fixes #368