### PR TITLE
Fixed update check to now support beta/alpha/nightly releases

### DIFF
--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -59,7 +59,7 @@ def get_version(version_string: str) -> Version:
     """Parse the version into a more usable format
 
     :param version_string: The version string. Eg 1.2 or 1.2.3.4 or 1.2.3.4b0
-    :return: (<release stage identifier>, (major, minor, patch)) beta will not exist if it is not a beta
+    :return: A Version object from the parsed version string
     """
     version_match = VERSION_REGEX.match(version_string)
     if version_match:

--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -115,7 +115,10 @@ class CheckForUpdate(threading.Thread):
                 key=lambda t: t[0],
                 reverse=True,
             ):
-                if release_version > current_version:
+                if (
+                    release_version > current_version
+                    and release_version.release_stage >= current_version.release_stage
+                ):
                     self._new_version = release_data["tag_name"]
                     break
 


### PR DESCRIPTION
Implemented a better update checking system, that now correctly identifies our versioning scheme.

Changes:
- Checking whether an update is valid is now based off of a version hierarchy (IE: Full releases only notify will notify users of new full releases, running a beta build will notify users of new beta or full releases, etc.)
- New nightly builds are correctly identified
- More efficient and accurate newest release finding
  - The old finding code sometimes would just find the next newest version, not the actual newest version
- Rudimentary checking for when running from source with a git installation to not show the update dialog