### PR TITLE
Improve NBT editor

### DIFF
--- a/amulet_map_editor/api/wx/ui/nbt_editor.py
+++ b/amulet_map_editor/api/wx/ui/nbt_editor.py
@@ -585,7 +585,7 @@ class EditTagDialog(wx.Frame):
 
 if __name__ == "__main__":
     level_dat = nbt.load(
-        r"C:\Users\gotharbg\Documents\Python Projects\Amulet-Core\tests\worlds_src\java_vanilla_1_13\level.dat"
+        b"\x0A\x00\x0B\x68\x65\x6C\x6C\x6F\x20\x77\x6F\x72\x6C\x64\x08\x00\x04\x6E\x61\x6D\x65\x00\x09\x42\x61\x6E\x61\x6E\x72\x61\x6D\x61\x00"
     )
 
     app = wx.App()

--- a/amulet_map_editor/api/wx/ui/nbt_editor.py
+++ b/amulet_map_editor/api/wx/ui/nbt_editor.py
@@ -20,6 +20,11 @@ nbt_resources = image.nbt
 class ParsedNBT:
     __slots__ = ["_parent", "_name", "_type"]
 
+    def __init__(self, parent, name, _type):
+        self._parent = parent
+        self._name = name
+        self._type = _type
+
     @classmethod
     def is_container(cls) -> bool:
         return False
@@ -73,10 +78,8 @@ class ParsedNBTValue(ParsedNBT):
         value: Union[int, float, str],
         _type: Type[nbt.AnyNBT],
     ):
-        self._parent: ParsedNBTContainer = parent
-        self._name = name
+        super(ParsedNBTValue, self).__init__(parent, name, _type)
         self._value = value
-        self._type = _type
 
     def __repr__(self):
         return f"{self._type}({self._name}, {self._value})"
@@ -107,11 +110,12 @@ class ParsedNBTContainer(ParsedNBT):
     __slots__ = ParsedNBT.__slots__ + ["_children"]
 
     def __init__(
-        self, parent: Optional[ParsedNBTContainer], name: str, _type: Type[nbt.AnyNBT]
+        self,
+        parent: Optional[ParsedNBTContainer],
+        name: str,
+        _type: Type[Union[nbt.AnyNBT, MutableMapping, MutableSequence]],
     ):
-        self._parent: ParsedNBTContainer = parent
-        self._name = name
-        self._type = _type
+        super(ParsedNBTContainer, self).__init__(parent, name, _type)
         self._children: List[Union[ParsedNBTValue, ParsedNBTContainer]] = []
 
     @classmethod
@@ -220,13 +224,17 @@ class NBTEditor(simple.SimplePanel):
             nbt.TAG_Compound: self.image_list.Add(
                 nbt_resources.nbt_tag_compound.bitmap()
             ),
-            nbt.NBTFile: self.image_list.ImageCount - 1,
+            nbt.NBTFile: self.image_list.Add(nbt_resources.nbt_tag_compound.bitmap()),
             nbt.TAG_List: self.image_list.Add(nbt_resources.nbt_tag_list.bitmap()),
             nbt.TAG_Byte_Array: self.image_list.Add(
                 nbt_resources.nbt_tag_array.bitmap()
             ),
-            nbt.TAG_Int_Array: self.image_list.ImageCount - 1,
-            nbt.TAG_Long_Array: self.image_list.ImageCount - 1,
+            nbt.TAG_Int_Array: self.image_list.Add(
+                nbt_resources.nbt_tag_array.bitmap()
+            ),
+            nbt.TAG_Long_Array: self.image_list.Add(
+                nbt_resources.nbt_tag_array.bitmap()
+            ),
         }
         self.other = self.image_map[nbt.TAG_String]
 
@@ -577,7 +585,7 @@ class EditTagDialog(wx.Frame):
 
 if __name__ == "__main__":
     level_dat = nbt.load(
-        r"C:\Users\gotharbg\Documents\Python Projects\Amulet-Core\tests\worlds_src\Java 1.13\level.dat"
+        r"C:\Users\gotharbg\Documents\Python Projects\Amulet-Core\tests\worlds_src\java_vanilla_1_13\level.dat"
     )
 
     app = wx.App()


### PR DESCRIPTION
Reworked the NBT editor to use an abstracted representation of a NBT structure instead of actual NBT objects. This allows for much cleaner handling of adding/removing items from container types (`TAG_Compound`/`TAG_List`), as well as simplifying the UI code to reduce the need to handle edge cases.

Changes:
- Input NBT objects are parsed to a representation format that keeps track of the parent containing it
- Tree building logic is less complex and cleaner
- NBT editing/adding dialogs are separate from each other
- Removed the need for a callback (current NBT state can be accessed via the `.nbt` property)