### PR TITLE
Fix window size restoring issues

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -41,7 +41,7 @@ class AmuletUI(wx.Frame):
             id=wx.ID_ANY,
             title=f"Amulet V{__version__}",
             pos=wx.DefaultPosition,
-            size=wx.Size(560, 400),
+            size=wx.Size(1000, 600),
             style=wx.CAPTION
             | wx.CLOSE_BOX
             | wx.MINIMIZE_BOX

--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -46,7 +46,6 @@ class AmuletUI(wx.Frame):
             | wx.CLOSE_BOX
             | wx.MINIMIZE_BOX
             | wx.MAXIMIZE_BOX
-            | wx.MAXIMIZE
             | wx.SYSTEM_MENU
             | wx.TAB_TRAVERSAL
             | wx.CLIP_CHILDREN

--- a/amulet_map_editor/programs/edit/api/chunk_generator.py
+++ b/amulet_map_editor/programs/edit/api/chunk_generator.py
@@ -31,7 +31,6 @@ if ThreadingEnabled:
                     self.thread_action()
                 time.sleep(1 / 60)
 
-
 else:
 
     class ChunkGenerator(ThreadedObjectContainer):


### PR DESCRIPTION
There were a number of issues with the code that saved and restored the window size after restarting the program.

Added an `is_full_screen` attribute to the config file to track if the window is full screen or not.
Restore the window to either windowed in the same location or full screen depending on the previous state.
Fixed an issue where the window started in full screen but showed the restore down button.
Made the window start in full screen the first time the program is loaded.
The config file now stores the non-maximised size. This allows the window to be start in full screen but be restored down to the size before full screening.
Increased the default app size a bit to fix #467 