### PR TITLE
Fixed build and bumped core version

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup
       run: |
         python -m build -C--global-option=--find-libs=True -C--global-option=--find-libs=True
-        python -m pip install dist/amulet_map_editor-*.whl
+        python -m pip install dist/amulet_map_editor-*.whl --upgrade
 
     - name: PyInstaller build
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 wxPython
 numpy
 pyopengl
-amulet-core~=1.4.0
+amulet-core~=1.6.0a0
 amulet-nbt~=1.0.3
 pymctranslate~=1.0.0
 minecraft-resource-pack~=1.2.0


### PR DESCRIPTION
Sometimes the build system caches the dependencies leading to two successive runs to sometimes use the old version.
This forces using the new version.
Bumped the core version to use the alpha versions of our core library