### PR TITLE
Improved dynamic import code

### DIFF
--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -3,12 +3,10 @@ from typing import List, Callable, Tuple, Type, Union, Optional
 import traceback
 import importlib
 import pkgutil
-import re
 
 from amulet.api.errors import LoaderNoneMatched
 from amulet import load_level
 
-import amulet_map_editor
 from amulet_map_editor import programs, log, lang
 from amulet_map_editor.api.datatypes import MenuData
 from amulet_map_editor.api.framework.pages import BasePageUI
@@ -24,23 +22,13 @@ _fixed_extensions: List[Tuple[str, Type[BaseProgram]]] = [
 def load_extensions():
     if not _extensions:
         _extensions.extend(_fixed_extensions)
-        prefix = f"{programs.__name__}."
 
         extensions = []
 
-        # source support
-        for _, name, _ in pkgutil.iter_modules(programs.__path__, prefix):
-            extensions.append(load_extension(name))
-
-        # pyinstaller support
-        toc = set()
-        for importer in pkgutil.iter_importers(amulet_map_editor.__name__):
-            if hasattr(importer, "toc"):
-                toc |= importer.toc
-        match = re.compile(f"^{re.escape(prefix)}[a-zA-Z0-9_]*$")
-        for name in toc:
-            if match.fullmatch(name):
-                extensions.append(load_extension(name))
+        for _, module_name, _ in pkgutil.iter_modules(
+            programs.__path__, f"{programs.__name__}."
+        ):
+            extensions.append(load_extension(module_name))
 
         _extensions.extend(
             sorted((ext for ext in extensions if ext is not None), key=lambda x: x[0])

--- a/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
+++ b/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
@@ -1,19 +1,18 @@
+import sys
 from typing import Tuple, Dict
 from types import ModuleType
 import os
 import traceback
 import pkgutil
 import importlib
-import re
 
 from .loader import (
     BaseOperationLoader,
     OperationLoader,
     UIOperationLoader,
 )
-from .util import STOCK_PLUGINS_DIR, STOCK_PLUGINS_NAME, CUSTOM_PLUGINS_DIR, load_module
+from .util import STOCK_PLUGINS_DIR, STOCK_PLUGINS_NAME, CUSTOM_PLUGINS_DIR
 
-import amulet_map_editor
 from amulet_map_editor import log
 
 
@@ -46,48 +45,77 @@ class BaseOperationManager:
         If new operations are created, load them.
         If old operations were removed, remove them."""
         self._operations.clear()
-        self._load_pyinstaller(f"{STOCK_PLUGINS_NAME}.{self._group_name}")
-        self._load_dir(os.path.join(STOCK_PLUGINS_DIR, self._group_name))
-        self._load_dir(os.path.join(CUSTOM_PLUGINS_DIR, self._group_name), True)
+        self._load_internal_submodules(
+            os.path.join(STOCK_PLUGINS_DIR, self._group_name),
+            ".".join([STOCK_PLUGINS_NAME, self._group_name]),
+        )
+        self._load_external_submodules(
+            os.path.join(CUSTOM_PLUGINS_DIR, self._group_name)
+        )
 
-    def _load_dir(self, path: str, make: bool = False):
-        """Load all operations in a set directory."""
-        if make:
-            os.makedirs(path, exist_ok=True)
-        if os.path.isdir(path):
-            for obj_name in os.listdir(path):
-                if obj_name in {"__init__.py", "__pycache__"}:
-                    continue
-                obj_path = os.path.join(path, obj_name)
-                if os.path.isfile(obj_path) and not obj_path.endswith(".py"):
-                    continue
-                try:
-                    mod = load_module(obj_path)
-                except ImportError:
-                    log.warning(
-                        f"Failed to import {obj_path}.\n{traceback.format_exc()}"
-                    )
-                else:
-                    self._load_module(obj_path, mod)
+    def _load_internal_submodules(self, package_path: str, package_name: str):
+        """
+        Load submodules from within a known package.
 
-    def _load_pyinstaller(self, package: str):
-        # pyinstaller support
-        toc = set()
-        for importer in pkgutil.iter_importers(amulet_map_editor.__name__):
-            if hasattr(importer, "toc"):
-                toc |= importer.toc
-        prefix = f"{package}."
-        match = re.compile(f"^{re.escape(prefix)}[a-zA-Z0-9_]*$")
-        for module_name in toc:
-            if match.fullmatch(module_name):
-                try:
-                    mod = importlib.import_module(module_name)
-                except ImportError:
-                    log.warning(
-                        f"Failed to import {module_name}.\n{traceback.format_exc()}"
+        :param package_path: The file path of the package to load submodules from.
+        :param package_name: The python path of the package to load submodules from.
+        """
+        self._load_submodules(package_path, f"{package_name}.")
+
+    def _load_external_submodules(self, path: str):
+        """
+        Load submodules from an external package.
+
+        Note that the path will be added to the system path.
+
+        :param path: The path to the directory to find modules in.
+        """
+        # clean the path
+        path = os.path.abspath(path)
+
+        # create the directory
+        os.makedirs(path, exist_ok=True)
+
+        if path not in sys.path:
+            # The path modules are loaded from should be on the system path
+            sys.path.append(path)
+
+        self._load_submodules(path)
+
+    def _load_submodules(self, path: str, package: str = ""):
+        """
+        Load all operations in a path.
+        You should not use this directly.
+        Use _load_internal_submodules or _load_external_submodules
+
+        :param path: The path to load modules from.
+        :param package: The package name prefix
+        """
+        # clean the path
+        path = os.path.abspath(path)
+
+        for _, module_name, _ in pkgutil.iter_modules([path]):
+            module_name = f"{package}{module_name}"
+            try:
+                mod = importlib.import_module(module_name)
+            except ImportError:
+                log.warning(
+                    f"Failed to import {module_name}.\n{traceback.format_exc()}"
+                )
+            else:
+                if (
+                    os.path.dirname(
+                        mod.__path__[0] if hasattr(mod, "__path__") else mod.__file__
                     )
-                else:
+                    == path
+                ):
+                    # If the loaded module is actually in the path it was loaded from.
+                    # There may be cases where the name is shadowed by another module.
                     self._load_module(module_name, mod)
+                else:
+                    log.warning(
+                        f"Module {module_name} shadows another module. Try using a different module name."
+                    )
 
     def _load_module(self, obj_path: str, mod: ModuleType):
         if hasattr(mod, "export"):

--- a/amulet_map_editor/programs/edit/api/operations/manager/util.py
+++ b/amulet_map_editor/programs/edit/api/operations/manager/util.py
@@ -1,4 +1,5 @@
 import os
+import pkgutil
 import sys
 from typing import Optional
 from types import ModuleType
@@ -10,32 +11,3 @@ from amulet_map_editor.programs.edit.plugins.operations import stock_plugins
 STOCK_PLUGINS_DIR: str = stock_plugins.__path__[0]
 STOCK_PLUGINS_NAME: str = stock_plugins.__name__
 CUSTOM_PLUGINS_DIR = os.path.abspath("plugins")
-
-
-def load_module(path: str) -> Optional[ModuleType]:
-    """Load a module or package from the file path.
-    If it is a module (a file ending .py) then path must be the path to this file.
-    If it is a package (a directory optionally containing an __init__.py file) then the path of the directory must be given.
-
-    :param path: The file path of the module/package.
-    :return: module if loaded else None
-    """
-    if os.path.isfile(path):
-        spec = importlib.util.spec_from_file_location(path, path)
-        if spec is None:
-            raise ImportError(f"Could not import {path}")
-        mod = importlib.util.module_from_spec(spec)
-    elif os.path.isdir(path):
-        spec = importlib.util.spec_from_file_location(
-            path,
-            os.path.join(path, "__init__.py"),
-        )
-        if spec is None:
-            raise ImportError(f"Could not import {path}")
-        mod = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = mod
-    else:
-        return
-
-    spec.loader.exec_module(mod)
-    return mod


### PR DESCRIPTION
PyInstaller has fixed an issue where frozen modules would not appear in pkgutil.iter_modules. This meant that the frozen modules were found and loaded twice now that it has been fixed.
Imports are now done purely through `importlib.import_module`
External modules are first added to the path which should resolve some issues with operations that are packages.

This fixes #511 