### PR TITLE
Increased minimum requirement for wxpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # if the below doesn't work please find an alternative from here: https://extras.wxpython.org/wxPython4/extras/linux/gtk3/
-wxPython
+wxPython>=4.1
 numpy
 pyopengl
 amulet-core~=1.6.0a0


### PR DESCRIPTION
We use wx.Image.SetDefaultLoadFlags which only exists in 4.1 and up.
Linux comes with an older version of wxpython which means the new one is not installed causing an error.
This will force the new version.