### PR TITLE
Improved world closing UI

### DIFF
--- a/amulet_map_editor/api/framework/pages/world_page.py
+++ b/amulet_map_editor/api/framework/pages/world_page.py
@@ -1,3 +1,6 @@
+import threading
+import time
+
 import wx
 from typing import List, Callable, Tuple, Type, Union, Optional
 import traceback
@@ -112,16 +115,35 @@ class WorldPageUI(wx.Notebook, BasePageUI):
         Check is_closeable before running this"""
         for ext in self._extensions:
             ext.close()
-        dialog = wx.ProgressDialog(
-            "Closing World",
-            "Please be patient. This may take a little while.",
-            maximum=100,
-            parent=self,
-            style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
-        )
-        dialog.Fit()
-        self.world.close()
-        dialog.Update(100)
+
+        closed = False
+
+        def close_world():
+            nonlocal closed
+            self.world.close()
+            closed = True
+
+        # close the world in a new thread
+        thread = threading.Thread(target=close_world)
+        thread.start()
+        # sleep a little
+        time.sleep(0.1)
+        if not closed:
+            # if not closed yet open a dialog to warn the user.
+            # We do this on a delay so that it does not flick up for a split second
+            dialog = wx.ProgressDialog(
+                "Closing World",
+                "Please be patient. This may take a little while.",
+                maximum=100,
+                style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME | wx.PD_AUTO_HIDE,
+            )
+            dialog.Fit()
+            dialog.Update(99)
+            # wait until the world is closed then close the dialog
+            while not closed:
+                wx.GetApp().Yield()
+                time.sleep(0.1)
+            dialog.Destroy()
 
     def _page_change(self, _):
         """Method to fire when the page is changed"""


### PR DESCRIPTION
Previously when the world was closed there was always a dialog that popped up to notify the user that it might take a while. This always shown even if only instantaneously.

This moves the closing logic to a new thread so that it does not block the UI and the closing notification is only shown if it takes more than 0.1 seconds to close.

This also fixes an issue where the UI would become unresponsive if the world save code ran too quickly. This was due to the close notification being present but hidden. I think this was related to dialog's parent being destroyed. Removing the parent seems to fix this.