### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 wxPython>=4.1
 numpy
 pyopengl
-amulet-core==1.6.*,>=1.6.0a0
+amulet-core~=1.6.0a0
 amulet-nbt~=1.0.3
 pymctranslate~=1.0.0
 minecraft-resource-pack~=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,7 @@ def freeze_requirements(packages: List[str]) -> List[str]:
         print("pip-install")
         try:
             # make sure pip is up to date
-            subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
-            )
+            subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
             # run pip install
             subprocess.run(
                 [sys.executable, "-m", "pip", "install", *packages, "--upgrade"]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ def freeze_requirements(packages: List[str]) -> List[str]:
     if any("~=" in r and r.split("~=", 1)[0].lower() in first_party for r in packages):
         print("pip-install")
         try:
+            # make sure pip is up to date
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
+            )
             # run pip install
             subprocess.run(
                 [sys.executable, "-m", "pip", "install", *packages, "--upgrade"]


### PR DESCRIPTION
Fixes #589 
When freezing requirements for a release the default version of pip was used which had a bug causing the wrong dependency version to be installed.
This updates the version of pip before installing so that the bug is not present.