### PR TITLE
Delete blocks does not create chunks

### DIFF
--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/internal_operations/delete.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/internal_operations/delete.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
-from amulet.operations.fill import fill
 from amulet.api.selection import SelectionGroup
 from amulet.api.block import UniversalAirBlock
 from amulet.api.data_types import Dimension, OperationReturnType
@@ -12,9 +13,13 @@ if TYPE_CHECKING:
 def delete(
     world: "BaseLevel", dimension: Dimension, selection: SelectionGroup
 ) -> OperationReturnType:
-    yield from fill(
-        world,
-        dimension,
-        selection,
-        UniversalAirBlock,
-    )
+    internal_id = world.block_palette.get_add_block(UniversalAirBlock)
+
+    iter_count = len(list(world.get_coord_box(dimension, selection, False)))
+    count = 0
+
+    for chunk, slices, _ in world.get_chunk_slice_box(dimension, selection, False):
+        chunk.blocks[slices] = internal_id
+        chunk.changed = True
+        count += 1
+        yield count / iter_count


### PR DESCRIPTION
Fixes #550 
Modified delete operation to only delete blocks in chunks that exists.
This means that chunks that do not exist will not be created.