### PR TITLE
fix system sound on nudge button

### DIFF
--- a/amulet_map_editor/programs/edit/api/ui/nudge_button.py
+++ b/amulet_map_editor/programs/edit/api/ui/nudge_button.py
@@ -49,7 +49,7 @@ class NudgeButton(wx.Button):
         label: str,
         tooltip: str,
     ):
-        super().__init__(parent, label=label)
+        super().__init__(parent, label=label, style=wx.WANTS_CHARS)
         self.SetToolTip(tooltip)
         self._camera = weakref.ref(camera)
         self._buttons = ButtonInput(self)


### PR DESCRIPTION
The nudge buttons used to sound the system invalid sound whenever it was used.

This style lets the window know that it should take key inputs thus disabling the system sound.

Fixes https://github.com/Amulet-Team/Amulet-Map-Editor/issues/272