### PR TITLE
Improved the update check mechanic

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -77,9 +77,11 @@ class AmuletUI(wx.Frame):
         if update_check:
             self.Bind(
                 update_check.EVT_UPDATE_CHECK,
-                lambda evt: update_check.show_update_window(self, __version__, evt),
+                lambda evt: update_check.UpdateDialog(
+                    self, __version__, evt.GetVersion()
+                ).ShowModal(),
             )
-            update_check.check_for_update(__version__, self)
+            update_check.check_for_update(self, __version__)
 
     def create_menu(self):
         menu_dict = {}

--- a/amulet_map_editor/api/framework/update_check.py
+++ b/amulet_map_editor/api/framework/update_check.py
@@ -1,130 +1,20 @@
 from __future__ import annotations
 
+from typing import Optional
 import urllib.request
 import threading
 import json
-import re
 import webbrowser
-from dataclasses import dataclass
-from enum import IntEnum
 
 import wx
+from packaging.version import Version
 
 from amulet_map_editor import lang
 
 URL = "http://api.github.com/repos/Amulet-Team/Amulet-Map-Editor/releases"
 
-"""
-VERSION_REGEX Documentation
-
-    This is not a documentation of regular expression syntax, just documentation on the subsequences that this regular expression looks for
-    For an in-depth guide on regular expressions, see here: https://www.debuggex.com/cheatsheet/regex/python
-    
-    Our version scheme allows for an optional "v" prefix, so that subsequence is tested by "v?"
-    
-    Since we use the Semantic Versioning scheme, our version numbers follow this format: <major>.<minor>.<patch>
-    with the <patch> number being optional (only if it's value would be 0 for that version)
-    That is tested by "(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?"
-    
-    - For the major and minor numbers, "(?P<major>\d+)" will match any non-zero number of digits and group them under the
-        "major" group (in this instance)
-    - "\." will then match the separating "." character
-    - Since the patch number is optional, "(\.(?P<patch>\d+))?" is used instead, the second "." is included in the 
-        optional group, but other wise the capturing group is the same as the major/minor numbers
-        
-    We then use an optional release type flag to denote whether the release is a beta or alpha release and it's number:
-    "((a(?P<alpha>\d+))|(b(?P<beta>\d+)))?"
-    
-    For our nightly builds, we also denote a unique build number with the prefix of ".dev": "(\.dev(?P<devnum>\d{12}))?"
-    
-    Finally, our version scheme also denotes when Amulet is being ran from source, while this information isn't
-    necessarily used for update checking, we use it to determine if the update dialog should be shown. If a commit 
-    hash/count is found in the version string of the current Amulet instance, the dialog is not shown. Our regular 
-    expression uses the following to detect that subsequence: 
-        "(\+(?P<commit_count>\d+)\.g(?P<commit_hash>[a-z\d]+)(\.dirty)?)?"
-        
-    - "commit_count" group signifies the number of commits since the last release
-    - "commit_hash" group is the current commit hash
-    - ".dirty" denotes whether uncommitted changes have been made 
-"""
-VERSION_REGEX = re.compile(
-    r"^v?(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?((a(?P<alpha>\d+))|(b(?P<beta>\d+)))?(\.dev(?P<devnum>\d{12}))?(\+(?P<commit_count>\d+)\.g(?P<commit_hash>[a-z\d]+)(\.dirty)?)?$"
-)
-
 _EVT_UPDATE_CHECK = wx.NewEventType()
 EVT_UPDATE_CHECK = wx.PyEventBinder(_EVT_UPDATE_CHECK, 1)
-
-
-class Release(IntEnum):
-    FULL = 0
-    BETA = -1
-    ALPHA = -2
-
-
-@dataclass
-class Version:
-    release_stage: int
-    major: int
-    minor: int
-    patch: int
-    alpha_number: int = -1
-    beta_number: int = -1
-    nightly_timestamp: int = -1
-    has_commit_hash: bool = False
-
-    def __gt__(self, other: Version):
-        if self.version_tuple > other.version_tuple:
-            return True
-        elif self.version_tuple == other.version_tuple:
-            if self.release_stage > other.release_stage:
-                return True
-            elif self.release_stage == other.release_stage:
-                if self.release_stage == Release.ALPHA:
-                    return self.alpha_number > other.alpha_number
-                elif self.release_stage == Release.BETA:
-                    if self.beta_number > other.beta_number:
-                        return True
-                    elif (
-                        self.beta_number == other.beta_number and self.beta_number != -1
-                    ):
-                        return self.nightly_timestamp > other.nightly_timestamp
-        return False
-
-    @property
-    def version_tuple(self):
-        return self.major, self.minor, self.patch
-
-
-def get_version(version_string: str) -> Version:
-    """Parse the version into a more usable format
-
-    :param version_string: The version string. Eg 1.2 or 1.2.3.4 or 1.2.3.4b0
-    :return: A Version object from the parsed version string
-    """
-    version_match = VERSION_REGEX.match(version_string)
-    if version_match:
-        v = version_match.groupdict()
-        major, minor = int(v["major"]), int(v["minor"])
-        if v["patch"] is None:
-            patch = 0
-        else:
-            patch = int(v["patch"])
-        version = Version(Release.FULL, major, minor, patch)
-
-        if v.get("alpha") is not None:
-            version.release_stage = Release.ALPHA
-            version.alpha_number = int(v["alpha"])
-        elif v.get("beta") is not None:
-            version.release_stage = Release.BETA
-            version.beta_number = int(v["beta"])
-            if v.get("devnum") is not None:
-                version.nightly_timestamp = int(v["devnum"])
-
-        if v.get("commit_hash") is not None:
-            version.has_commit_hash = True
-        return version
-
-    raise Exception(f"Invalid version string {version_string}")
 
 
 class UpdateEvent(wx.PyCommandEvent):
@@ -136,46 +26,9 @@ class UpdateEvent(wx.PyCommandEvent):
         return self._new_version
 
 
-class CheckForUpdate(threading.Thread):
-    def __init__(self, url, current_version, parent):
-        threading.Thread.__init__(self)
-        self.url = url
-        self.current_version = current_version
-        self._parent = parent
-        self._new_version = None
-
-    def run(self):
-        try:
-            conn = urllib.request.urlopen(self.url, timeout=5)
-            data = conn.read()
-            data = json.loads(data)
-            try:
-                current_version = get_version(self.current_version)
-            except Exception:
-                return
-
-            for release_version, release_data in sorted(
-                map(lambda d: (get_version(d["tag_name"]), d), data),
-                key=lambda t: t[0],
-                reverse=True,
-            ):
-                if (
-                    release_version > current_version
-                    and release_version.release_stage >= current_version.release_stage
-                ):
-                    self._new_version = release_data["tag_name"]
-                    break
-
-            if self._new_version:
-                evt = UpdateEvent(_EVT_UPDATE_CHECK, -1, self._new_version)
-                wx.PostEvent(self._parent, evt)
-        except Exception:
-            pass
-
-
 class UpdateDialog(wx.Dialog):
     def __init__(self, parent, current_version: str, new_version: str):
-        wx.Dialog.__init__(self, parent)
+        super().__init__(parent)
 
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
 
@@ -220,13 +73,66 @@ class UpdateDialog(wx.Dialog):
         )
 
 
-def show_update_window(parent, current_version: str, evt: UpdateEvent):
-    if get_version(current_version).has_commit_hash:
-        print("Running from source, not showing update dialog")
-        return
-    UpdateDialog(parent, current_version, evt.GetVersion()).ShowModal()
+def _is_compatible(current_version: Version, release_version: Version) -> bool:
+    """The release version is only compatible with the current version if it is newer and more stable."""
+    # release > beta > beta.dev > alpha.dev
+    #                > alpha > alpha.dev
+    def get_release_stage(version: Version) -> int:
+        if version.pre is None:
+            return 3
+        else:
+            return {"a": 0, "b": 1, "rc": 2}[version.pre[0]]
+
+    return (
+        # The release version is newer than the current version
+        release_version > current_version
+        # the pre-release stage is newer or the same
+        and get_release_stage(release_version) >= get_release_stage(current_version)
+        # dev builds should only be suggested if the current version is a dev build
+        and (release_version.dev is None or current_version.dev is not None)
+    )
 
 
-def check_for_update(version, listening_parent):
-    update_thread = CheckForUpdate(URL, version, listening_parent)
+def _get_newest_version(url: str, current_version_str: str) -> Optional[str]:
+    """Find a newer but compatible release than this one if one exists."""
+
+    try:
+        current_version = Version(current_version_str)
+
+        if current_version.local is not None:
+            # if the version has a local extension (eg. "+0.gee5780.dirty")
+            print("Running from source, not showing update dialog")
+            return
+
+        conn = urllib.request.urlopen(url, timeout=5)
+        data = conn.read()
+        data = json.loads(data)
+
+        # iterate through all release versions starting with the newest
+        for release_version, release_data in sorted(
+            map(lambda d: (Version(d["tag_name"]), d), data),
+            key=lambda t: t[0],
+            reverse=True,
+        ):
+            if _is_compatible(current_version, release_version):
+                return str(release_version)
+
+    except Exception:
+        pass
+
+
+def _check_for_update(
+    listening_parent: wx.EvtHandler, url: str, current_version_str: str
+):
+    """Check if there is a newer release and post an UpdateEvent if there is."""
+    release_version = _get_newest_version(url, current_version_str)
+    if release_version is not None:
+        evt = UpdateEvent(_EVT_UPDATE_CHECK, -1, str(release_version))
+        wx.PostEvent(listening_parent, evt)
+
+
+def check_for_update(listening_parent: wx.EvtHandler, current_version_str: str):
+    update_thread = threading.Thread(
+        target=_check_for_update, args=(listening_parent, URL, current_version_str)
+    )
     update_thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 wxPython>=4.1
 numpy
 pyopengl
+packaging
 amulet-core~=1.7.0
 amulet-nbt~=1.0.4
 pymctranslate~=1.1.0


### PR DESCRIPTION
The previous method relied on custom parsing and comparison.
This switches to the packaging library which handles all of that for us.
Split up the logic a bit to make testing easier.
Replaced CheckForUpdate class with a function passed to the thread.
Versions will only be suggested if they are newer and more stable. This was the intended behaviour before but it was a little broken.