### PR TITLE
Added a button to open the operation folder

### DIFF
--- a/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
+++ b/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
@@ -31,6 +31,10 @@ class BaseOperationManager:
         self.reload()
 
     @property
+    def public_path(self) -> str:
+        return os.path.abspath(os.path.join(CUSTOM_PLUGINS_DIR, self._group_name))
+
+    @property
     def operations(self) -> Tuple[BaseOperationLoader, ...]:
         return tuple(self._operations.values())
 
@@ -49,9 +53,7 @@ class BaseOperationManager:
             os.path.join(STOCK_PLUGINS_DIR, self._group_name),
             ".".join([STOCK_PLUGINS_NAME, self._group_name]),
         )
-        self._load_external_submodules(
-            os.path.join(CUSTOM_PLUGINS_DIR, self._group_name)
-        )
+        self._load_external_submodules(self.public_path)
 
     def _load_internal_submodules(self, package_path: str, package_name: str):
         """
@@ -70,8 +72,6 @@ class BaseOperationManager:
 
         :param path: The path to the directory to find modules in.
         """
-        # clean the path
-        path = os.path.abspath(path)
 
         # create the directory
         os.makedirs(path, exist_ok=True)

--- a/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
@@ -1,9 +1,12 @@
 import wx
 from typing import TYPE_CHECKING, Optional
 import traceback
+import os
+import sys
+import subprocess
 
 from amulet_map_editor import log
-from amulet_map_editor.api.image import REFRESH_ICON
+from amulet_map_editor.api import image
 from amulet_map_editor.api.wx.ui.simple import SimpleChoiceAny
 from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 
@@ -19,6 +22,8 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
     OperationGroupName = None
     _active_operation: Optional[OperationUIType]
 
+    ShowOpenFolder = True
+
     def __init__(self, canvas: "EditCanvas"):
         wx.BoxSizer.__init__(self, wx.VERTICAL)
         BaseToolUI.__init__(self, canvas)
@@ -28,29 +33,36 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
 
         horizontal_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self._operation_choice = SimpleChoiceAny(self.canvas)
-        self._reload_operation = wx.BitmapButton(
-            self.canvas, bitmap=REFRESH_ICON.bitmap(16, 16)
-        )
-        self._reload_operation.SetToolTip("Reload Operations")
-
-        horizontal_sizer.Add(self._operation_choice)
-        horizontal_sizer.Add(self._reload_operation)
-
-        self.Add(horizontal_sizer)
-
         assert isinstance(
             self.OperationGroupName, str
         ), "OperationGroupName has not been set or is not a string."
-
+        # The operation selection
+        self._operation_choice = SimpleChoiceAny(self.canvas)
+        horizontal_sizer.Add(self._operation_choice)
         self._operations = UIOperationManager(self.OperationGroupName)
-
         self._operation_choice.SetItems(
             {op.identifier: op.name for op in self._operations.operations}
         )
         self._operation_choice.Bind(wx.EVT_CHOICE, self._on_operation_change)
 
+        # The reload button
+        self._reload_operation = wx.BitmapButton(
+            self.canvas, bitmap=image.REFRESH_ICON.bitmap(16, 16)
+        )
+        self._reload_operation.SetToolTip("Reload Operations")
+        horizontal_sizer.Add(self._reload_operation)
         self._reload_operation.Bind(wx.EVT_BUTTON, self._on_reload_operations)
+
+        # The open folder button
+        if self.ShowOpenFolder:
+            self._open_folder = wx.BitmapButton(
+                self.canvas, bitmap=image.TABLERICONS.folder.bitmap(16, 16)
+            )
+            self._open_folder.SetToolTip("Open Plugin Folder")
+            horizontal_sizer.Add(self._open_folder)
+            self._open_folder.Bind(wx.EVT_BUTTON, self._on_open_folder)
+
+        self.Add(horizontal_sizer)
 
         self._operation_sizer = wx.BoxSizer(wx.VERTICAL)
         self.Add(self._operation_sizer, 1, wx.EXPAND)
@@ -161,3 +173,13 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
 
             self._setup_operation()
             self.canvas.reset_bound_events()
+
+    def _on_open_folder(self, evt):
+        path = self._operations.public_path
+        if not os.path.exists(path):
+            os.makedirs(path)
+        if sys.platform == "win32":
+            os.startfile(path)
+        else:
+            opener = "open" if sys.platform == "darwin" else "xdg-open"
+            subprocess.call([opener, path])

--- a/amulet_map_editor/programs/edit/plugins/tools/export_tool.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/export_tool.py
@@ -3,6 +3,7 @@ from amulet_map_editor.programs.edit.api.ui.tool import BaseOperationChoiceToolU
 
 class ExportTool(BaseOperationChoiceToolUI):
     OperationGroupName = "export_operations"
+    ShowOpenFolder = False
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
The operation could be difficult to find.
This adds a button to the right of the reload button that when clicked will open the folder where the operations are loaded from in the system explorer.
Fixed #453