### PR TITLE
Paste latest when opening paste tool

### DIFF
--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -39,7 +39,6 @@ from amulet_map_editor.programs.edit.api.events import (
     RedoEvent,
     CreateUndoEvent,
     SaveEvent,
-    PasteEvent,
     ToolChangeEvent,
     EVT_EDIT_CLOSE,
 )
@@ -265,8 +264,12 @@ class EditCanvas(BaseEditCanvas):
         assert (
             dimension in structure.dimensions
         ), "The requested dimension does not exist for this object."
-        wx.PostEvent(self, ToolChangeEvent(tool="Paste"))
-        wx.PostEvent(self, PasteEvent(structure=structure, dimension=dimension))
+        wx.PostEvent(
+            self,
+            ToolChangeEvent(
+                tool="Paste", state={"structure": structure, "dimension": dimension}
+            ),
+        )
 
     def paste_from_cache(self):
         if structure_cache:

--- a/amulet_map_editor/programs/edit/api/events.py
+++ b/amulet_map_editor/programs/edit/api/events.py
@@ -1,3 +1,4 @@
+import wx
 from wx.lib import newevent
 
 from amulet_map_editor.api.opengl.camera import (
@@ -31,8 +32,18 @@ from .selection import SelectionChangeEvent, EVT_SELECTION_CHANGE
 DimensionChangeEvent, EVT_DIMENSION_CHANGE = newevent.NewEvent()
 
 # the active tool changed
-ToolChangeEvent, EVT_TOOL_CHANGE = newevent.NewEvent()
-PasteEvent, EVT_PASTE = newevent.NewEvent()
+_ToolChangeEventType = wx.NewEventType()
+EVT_TOOL_CHANGE = wx.PyEventBinder(_ToolChangeEventType)
+
+
+class ToolChangeEvent(wx.PyEvent):
+    """Run when the camera has moved or rotated."""
+
+    def __init__(self, tool: str, state=None):
+        wx.PyEvent.__init__(self, eventType=_ToolChangeEventType)
+        self.tool = tool
+        self.state = state
+
 
 UndoEvent, EVT_UNDO = newevent.NewEvent()
 RedoEvent, EVT_REDO = newevent.NewEvent()

--- a/amulet_map_editor/programs/edit/api/ui/tool/base_tool_ui.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/base_tool_ui.py
@@ -1,5 +1,5 @@
 import wx
-from typing import Union
+from typing import Union, Any
 
 from amulet_map_editor.programs.edit.api.edit_canvas_container import (
     EditCanvasContainer,
@@ -25,6 +25,16 @@ class BaseToolUI(EditCanvasContainer, CanvasToggleElement):
     def bind_events(self):
         """Bind all required events to the canvas.
         All events on the canvas will be automatically removed after the tool is disabled.
+        """
+        pass
+
+    def set_state(self, state: Any):
+        """
+        Set any state data.
+        In some cases one tool might bounce to another and want to do more than just starting it.
+        This will get called after enabling the tool.
+
+        :param state: The state to set. Validate that this data is correct because it may come from anywhere.
         """
         pass
 

--- a/amulet_map_editor/programs/edit/api/ui/tool_manager.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool_manager.py
@@ -73,9 +73,8 @@ class ToolManagerSizer(wx.BoxSizer, EditCanvasContainer):
         self._tools[tool.name] = tool
         self._tool_option_sizer.Add(tool, 1, wx.EXPAND, 0)
 
-    def _enable_tool_event(self, evt):
-        self._enable_tool(evt.tool)
-        # evt.Skip() # this causes issues if uncommented
+    def _enable_tool_event(self, evt: ToolChangeEvent):
+        self._enable_tool(evt.tool, evt.state)
 
     def enable(self):
         if isinstance(self._active_tool, SelectTool):
@@ -97,7 +96,7 @@ class ToolManagerSizer(wx.BoxSizer, EditCanvasContainer):
         if not isinstance(self._active_tool, SelectTool):
             self._enable_tool("Select")
 
-    def _enable_tool(self, tool: str):
+    def _enable_tool(self, tool: str, state=None):
         if tool in self._tools:
             if self._active_tool is not None:
                 self._active_tool.disable()
@@ -111,6 +110,7 @@ class ToolManagerSizer(wx.BoxSizer, EditCanvasContainer):
             elif isinstance(self._active_tool, wx.Sizer):
                 self._active_tool.ShowItems(show=True)
             self._active_tool.enable()
+            self._active_tool.set_state(state)
             self.canvas.reset_bound_events()
             self.canvas.Layout()
 


### PR DESCRIPTION
Changes the behaviour of the paste tool mechanic to automatically bring up the last copied structure when opened. Before the UI would remain greyed out.

Replaced the paste event with an extra attribute in the tool change event.
Fixed #618