### PR TITLE
Added numpy.import_array()

### DIFF
--- a/amulet_map_editor/api/opengl/mesh/level/chunk/chunk_builder_cy.pyx
+++ b/amulet_map_editor/api/opengl/mesh/level/chunk/chunk_builder_cy.pyx
@@ -4,6 +4,7 @@
 
 import numpy
 cimport numpy
+numpy.import_array()
 
 from libc.stdlib cimport malloc, calloc, free
 


### PR DESCRIPTION
This is apparently required in some situations and is better to have it than not.
I hit the error of not having it once but I cannot reproduce it.