### PR TITLE
Added a dialog to welcome and warn new users

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -5,11 +5,13 @@ from typing import Dict, Union
 import traceback
 
 from amulet.api.errors import LoaderNoneMatched
+from amulet_map_editor.api import config
 from amulet_map_editor.api.wx.ui.select_world import open_level_from_dialog
 from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor import __version__, lang, log
 from amulet_map_editor.api.framework.pages import WorldPageUI
 from .pages import AmuletMainMenu, BasePageUI
+from .warning_dialog import WarningDialog
 
 from amulet_map_editor.api import image
 from amulet_map_editor.api.wx.util.ui_preferences import preserve_ui_preferences
@@ -66,6 +68,14 @@ class AmuletUI(wx.Frame):
         self._level_notebook.init()
 
         self.Bind(wx.EVT_CLOSE, self._level_notebook.on_app_close)
+
+        meta_config = config.get("amulet_meta", {})
+        if not meta_config.get("do_not_show_warning_dialog", False):
+            warning_dialog = WarningDialog(self)
+            warning_dialog.ShowModal()
+            if warning_dialog.do_not_show_again:
+                meta_config["do_not_show_warning_dialog"] = True
+                config.put("amulet_meta", meta_config)
 
         if update_check:
             self.Bind(

--- a/amulet_map_editor/api/framework/warning_dialog.py
+++ b/amulet_map_editor/api/framework/warning_dialog.py
@@ -1,0 +1,46 @@
+import wx
+from amulet_map_editor import lang
+
+
+class WarningDialog(wx.Dialog):
+    def __init__(self, parent: wx.Window):
+        super().__init__(parent, style=wx.CAPTION)
+        self.SetTitle(lang.get("warning_dialog.title"))
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        content = wx.StaticText(
+            self,
+            wx.ID_ANY,
+            lang.get("warning_dialog.content"),
+            style=wx.ALIGN_CENTER_HORIZONTAL,
+        )
+        content.Wrap(750)
+        main_sizer.Add(content, 1, wx.ALL | wx.EXPAND, 5)
+
+        button_sizer = wx.StdDialogButtonSizer()
+        main_sizer.Add(button_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 4)
+
+        self._do_not_show = wx.CheckBox(
+            self, wx.ID_ANY, lang.get("warning_dialog.do_not_show_again")
+        )
+        button_sizer.Add(self._do_not_show, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+
+        self._understand_button = wx.Button(
+            self, wx.ID_ANY, lang.get("warning_dialog.i_understand")
+        )
+        self._understand_button.SetDefault()
+        button_sizer.Add(self._understand_button, 0, 0, 0)
+
+        button_sizer.Realize()
+
+        self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
+
+        self.SetAffirmativeId(self._understand_button.GetId())
+
+        self.Layout()
+
+    @property
+    def do_not_show_again(self) -> bool:
+        return self._do_not_show.GetValue()

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -50,6 +50,12 @@ main_menu.open_world=Open World
 main_menu.help=Help
 main_menu.discord=Amulet Discord
 
+# Warning Dialog
+warning_dialog.title=Welcome to Amulet
+warning_dialog.content=Hello and welcome to Amulet.\n\nWe suggest creating backups of your worlds before opening them in Amulet.\n\nWe try to make sure that Amulet does not corrupt worlds but the save format is undocumented and constantly changing and sometimes we just get things wrong.\n\nFor these reasons we only officially support full releases we have tested against.\nJava snapshots, Bedrock betas and experimental features may work but are untested so not officially supported.\n\nCurrently entities are not supported and items are only supported within the same platform.\nIf you find a feature you want added or a bug that needs fixing report it on our bug tracker.\nPlease use the search tool to see if it has been reported before creating a new ticket.\n\nIf you are new we suggest reading the user manual to familiarise yourself with the program.\n\n- The Amulet Team
+warning_dialog.do_not_show_again=Do not show this again
+warning_dialog.i_understand=I Understand
+
 # Update check
 ## The window displayed when a newer version of Amulet is available
 update_check.newer_version_released=A new version of Amulet has been released!


### PR DESCRIPTION
Adds a dialog to welcome new users and warn them about things such as backing up worlds and features that are not yet implemented.

This dialog opens before the actual Amulet UI does and has to be accepted to continue to the actual UI.

![image](https://user-images.githubusercontent.com/11940194/166907489-f0fc5519-60a2-4473-a881-f9a9052a4fdc.png)
