### PR TITLE
Added a config for the stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Only check tickets with this tag
+onlyLabels: ["state: more information needed"]
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels: []
+# Label to use when marking an issue as stale
+staleLabel: "state: stale"
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to inactivity.
+  Thank you for your contributions.


### PR DESCRIPTION
This adds a config file that the stale bot needs to run.
It will only mark tickets as stale if they have the "state: more information needed" label.
7 days after having that tag with no activity the "state: stale" label will be added and the default message written.
14 days after that with no activity the issue will be closed.