### PR TITLE
Implemented console scripts

### DIFF
--- a/amulet_map_editor/__main__.py
+++ b/amulet_map_editor/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-if __name__ == "__main__":
+
+def main():
     try:
         import sys
 
@@ -41,3 +42,7 @@ if __name__ == "__main__":
                 f"Amulet Crashed. Sorry about that. Please report it to a developer if you think this is an issue. \n{traceback.format_exc()}"
             )
             input("Press ENTER to continue.")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,9 @@ dependency_links =
     https://github.com/gentlegiantJGC/Minecraft-Model-Reader
     https://github.com/gentlegiantJGC/PyMCTranslate
     https://github.com/Amulet-Team/Amulet-NBT
+
+[options.entry_points]
+console_scripts =
+    amulet_map_editor = amulet_map_editor.__main__:main
+gui_scripts =
+    amulet_map_editor_no_console = amulet_map_editor.__main__:main


### PR DESCRIPTION
This allows typing `amulet_map_editor` in the console and it will run the main function removing the need to have `python -m` before.
Apparently this is used by pipx

This resolves #416 
