### PR TITLE
Made the traceback dialog scroll if the text is too long

### DIFF
--- a/amulet_map_editor/api/wx/ui/traceback_dialog.py
+++ b/amulet_map_editor/api/wx/ui/traceback_dialog.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import wx
-import wx.lib.expando
 from amulet_map_editor.api import image
 
 
@@ -36,7 +35,7 @@ class TracebackDialog(wx.Dialog):
         error_text = wx.StaticText(self, wx.ID_ANY, error)
         error_sizer.Add(error_text, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
-        traceback_text = wx.lib.expando.ExpandoTextCtrl(
+        traceback_text = wx.TextCtrl(
             self,
             wx.ID_ANY,
             traceback,


### PR DESCRIPTION
Long error messages could flow off the end of the traceback dialog.
This goes back to the TextCtrl (not sure why I was using the ExpandoTextCtrl) which has scrolling enabled by default.