### PR TITLE
Improved the OpenGL handling

### DIFF
--- a/amulet_map_editor/api/opengl/canvas/canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/canvas.py
@@ -1,9 +1,11 @@
+from typing import Optional
+import logging
+
 import wx
 from wx import glcanvas
 from OpenGL.GL import (
     GL_DEPTH_TEST,
     glEnable,
-    glGenTextures,
     GL_CULL_FACE,
     glDepthFunc,
     GL_LEQUAL,
@@ -11,16 +13,31 @@ from OpenGL.GL import (
     glBlendFunc,
     GL_SRC_ALPHA,
     GL_ONE_MINUS_SRC_ALPHA,
-    glDeleteTextures,
+    glGetString,
+    GL_VERSION,
 )
 
-import uuid
-import sys
+log = logging.getLogger(__name__)
+
+
+"""OpenGL workflow:
+The initialisation function should be as minimal as possible. No OpenGL functions should be called here. The OpenGL state is not valid until the window is first shown.
+You can implement functions that take a while in threads to not block the GUI but they must still not contain OpenGL functions.
+Upon the window being shown the OpenGL context is activated and the state can be set in _init_opengl
+Objects that need to bind textures or data should do so in the draw function so they can be sure the context is set.
+"""
 
 
 class BaseCanvas(glcanvas.GLCanvas):
+    _context: Optional[glcanvas.GLContext]
+
     def __init__(self, parent: wx.Window):
-        display_attributes = wx.glcanvas.GLAttributes()
+        """
+        Construct the canvas.
+        No OpenGL interaction should be done here.
+        OpenGL initialisation should be done in _init_opengl which is run after the window is first shown.
+        """
+        display_attributes = glcanvas.GLAttributes()
         display_attributes.PlatformDefaults().MinRGBA(8, 8, 8, 8).DoubleBuffer().Depth(
             24
         ).EndList()
@@ -31,32 +48,41 @@ class BaseCanvas(glcanvas.GLCanvas):
             style=wx.WANTS_CHARS,
         )
 
-        # create a UUID for the context. Used to get shaders
-        self._context_identifier = str(uuid.uuid4())
+        self._context = glcanvas.GLContext(self)
+        if not self._context.IsOK():
+            raise Exception(f"Failed setting up context")
 
-        if sys.platform == "linux":
-            # setup the OpenGL context. This apparently fixes #84
-            self._context = glcanvas.GLContext(self)
-        else:
-            context_attributes = wx.glcanvas.GLContextAttrs()
-            context_attributes.CoreProfile().Robust().ResetIsolation().EndList()
-            self._context = glcanvas.GLContext(
-                self, ctxAttrs=context_attributes
-            )  # setup the OpenGL context
-        self.SetCurrent(self._context)
-        self._gl_texture_atlas = glGenTextures(1)  # Create the atlas texture location
-        self._setup_opengl()  # set some OpenGL states
+        # self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+
+        self._init = False
+
+        self.Bind(wx.EVT_SHOW, self._on_show)
+
+    @property
+    def context(self) -> glcanvas.GLContext:
+        return self._context
 
     @property
     def context_identifier(self) -> str:
-        return self._context_identifier
+        # if not self._init:
+        #     raise Exception("Cannot access the context until the window has been shown.")
+        return str(id(self._context))
 
-    def _setup_opengl(self):
+    def _on_show(self, evt: wx.ShowEvent):
+        if not self._init and evt.IsShown():
+            print("show")
+            self._init = True
+            self._init_opengl()
+
+    def _init_opengl(self):
+        """Set up the OpenGL state after the window is first shown."""
+        self.SetCurrent(self._context)
+        gl_version = glGetString(GL_VERSION)
+        if isinstance(gl_version, bytes):
+            gl_version = gl_version.decode("utf-8")
+        log.info(f"OpenGL Version {gl_version}")
         glEnable(GL_DEPTH_TEST)
         glEnable(GL_CULL_FACE)
         glDepthFunc(GL_LEQUAL)
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-
-    def close(self):
-        glDeleteTextures([self._gl_texture_atlas])

--- a/amulet_map_editor/api/opengl/canvas/canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/canvas.py
@@ -68,7 +68,6 @@ class BaseCanvas(glcanvas.GLCanvas):
 
     def _on_show(self, evt: wx.ShowEvent):
         if not self._init and evt.IsShown():
-            print("show")
             self._init = True
             self._init_opengl()
 

--- a/amulet_map_editor/api/opengl/canvas/canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/canvas.py
@@ -52,8 +52,6 @@ class BaseCanvas(glcanvas.GLCanvas):
         if not self._context.IsOK():
             raise Exception(f"Failed setting up context")
 
-        # self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
-
         self._init = False
 
         self.Bind(wx.EVT_SHOW, self._on_show)

--- a/amulet_map_editor/api/opengl/canvas/event_canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/event_canvas.py
@@ -9,8 +9,8 @@ class EventCanvas(BaseCanvas):
     """A modification of the normal canvas to make it easier to add and remove events."""
 
     def __init__(self, parent: wx.Window):
-        super().__init__(parent)
         self._bound_events: List[Tuple[wx.PyEventBinder, Any, Any]] = []
+        super().__init__(parent)
 
     def reset_bound_events(self):
         """Unbind all events and re-bind the default events.

--- a/amulet_map_editor/api/opengl/mesh/level/level.py
+++ b/amulet_map_editor/api/opengl/mesh/level/level.py
@@ -60,9 +60,7 @@ class RenderLevel(OpenGLResourcePackManager, Drawable, ThreadedObject, ContextMa
         self._draw_floor = draw_floor
         self._draw_ceil = draw_ceil
         self._limit_bounds = limit_bounds
-        self._selection = GreenRenderSelectionGroup(
-            context_identifier, self.resource_pack, self.level.bounds(self.dimension)
-        )
+        self._selection = None
         self._chunk_manager = ChunkManager(self.context_identifier, self.resource_pack)
 
         self._last_rebuild_camera_location: Optional[
@@ -272,6 +270,12 @@ class RenderLevel(OpenGLResourcePackManager, Drawable, ThreadedObject, ContextMa
     def draw(self, camera_matrix: TransformationMatrix):
         self._chunk_manager.draw(camera_matrix, self.camera_location)
         if self._draw_box:
+            if self._selection is None:
+                self._selection = GreenRenderSelectionGroup(
+                    self.context_identifier,
+                    self.resource_pack,
+                    self.level.bounds(self.dimension),
+                )
             self._selection.draw(
                 camera_matrix,
                 self.camera_location,

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -198,16 +198,19 @@ class BaseEditCanvas(EventCanvas):
             self._opengl_resource_pack,
         )
 
-        try:
-            player = self.world.get_player(LOCAL_PLAYER)
-            self._camera.location_rotation = player.location, player.rotation
-            self.dimension = player.dimension
-        except:
-            self._camera.location_rotation = (0.0, 100.0, 0.0), (45.0, 45.0)
-
     def _init_opengl(self):
         super()._init_opengl()
         glClearColor(*self.background_colour, 1.0)
+
+        try:
+            player = self.world.get_player(LOCAL_PLAYER)
+            location, rotation = player.location, player.rotation
+            self.dimension = player.dimension
+        except:
+            location, rotation = (0.0, 100.0, 0.0), (45.0, 45.0)
+
+        self._camera.location_rotation = location, rotation
+        self._renderer.move_camera(location, rotation)
 
     def bind_events(self):
         """Set up all events required to run.

--- a/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/base_edit_canvas.py
@@ -56,9 +56,6 @@ class BaseEditCanvas(EventCanvas):
 
     def __init__(self, parent: wx.Window, world: BaseLevel):
         super().__init__(parent)
-        glClearColor(*self.background_colour, 1.0)
-        self.Hide()
-
         self._world = weakref.ref(world)
 
         self._selection: Optional[SelectionHistoryManager] = SelectionHistoryManager(
@@ -92,7 +89,7 @@ class BaseEditCanvas(EventCanvas):
     def thread_setup(self) -> Generator[OperationYieldType, None, None]:
         """
         Set up objects that take a while to set up.
-        All code in here must be thread safe.
+        All code in here must be thread safe and not touch the OpenGL state.
         """
         packs = []
         user_packs = [
@@ -191,6 +188,7 @@ class BaseEditCanvas(EventCanvas):
         """
         Any logic that needs to be run after everything has been set up.
         Code here will be run from the main thread.
+        The canvas has still not been shown here so do not touch the OpenGL state. Do this in _init_opengl.
         """
         yield 1.0, lang.get("program_3d_edit.canvas.setting_up_renderer")
         self._renderer: Optional[Renderer] = Renderer(
@@ -206,6 +204,10 @@ class BaseEditCanvas(EventCanvas):
             self.dimension = player.dimension
         except:
             self._camera.location_rotation = (0.0, 100.0, 0.0), (45.0, 45.0)
+
+    def _init_opengl(self):
+        super()._init_opengl()
+        glClearColor(*self.background_colour, 1.0)
 
     def bind_events(self):
         """Set up all events required to run.
@@ -234,7 +236,6 @@ class BaseEditCanvas(EventCanvas):
     def close(self):
         """Destroy all contained data so that the window can be safely destroyed."""
         self.renderer.close()
-        super().close()
 
     @property
     def world(self) -> BaseLevel:

--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -149,6 +149,9 @@ class EditCanvas(BaseEditCanvas):
         self._tool_sizer: Optional[ToolManagerSizer] = None
         self.buttons.register_actions(self.key_binds)
 
+        self._canvas_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(self._canvas_sizer)
+
         # Tracks if an operation has been started and not finished.
         self._operation_running = False
         # This lock stops two threads from editing the world simultaneously
@@ -157,14 +160,14 @@ class EditCanvas(BaseEditCanvas):
 
     def post_thread_setup(self) -> Generator[OperationYieldType, None, None]:
         yield from super().post_thread_setup()
-        canvas_sizer = wx.BoxSizer(wx.VERTICAL)
-        self.SetSizer(canvas_sizer)
-
         self._file_panel = FilePanel(self)
-        canvas_sizer.Add(self._file_panel, 0, wx.EXPAND, 0)
+        self._canvas_sizer.Add(self._file_panel, 0, wx.EXPAND, 0)
 
+    def _init_opengl(self):
+        super()._init_opengl()
         self._tool_sizer = ToolManagerSizer(self)
-        canvas_sizer.Add(self._tool_sizer, 1, wx.EXPAND, 0)
+        self._canvas_sizer.Add(self._tool_sizer, 1, wx.EXPAND, 0)
+        # self.enable()
 
     def bind_events(self):
         """Set up all events required to run.

--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -167,7 +167,6 @@ class EditCanvas(BaseEditCanvas):
         super()._init_opengl()
         self._tool_sizer = ToolManagerSizer(self)
         self._canvas_sizer.Add(self._tool_sizer, 1, wx.EXPAND, 0)
-        # self.enable()
 
     def bind_events(self):
         """Set up all events required to run.

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -188,9 +188,10 @@ class Renderer(EditCanvasContainer):
 
     def _on_camera_moved(self, evt: CameraMovedEvent):
         """The camera has moved. Update each class's camera state."""
-        location = evt.camera_location
-        rotation = evt.camera_rotation
+        self.move_camera(evt.camera_location, evt.camera_rotation)
+        evt.Skip()
 
+    def move_camera(self, location, rotation):
         # TODO: add combined methods
         self.render_world.camera_location = location
         self.render_world.camera_rotation = rotation
@@ -199,8 +200,6 @@ class Renderer(EditCanvasContainer):
         self.fake_levels.set_camera_rotation(*rotation)
 
         self.sky_box.set_camera_location(location)
-
-        evt.Skip()
 
     def _do_draw(self, evt):
         wx.PostEvent(self.canvas, PreDrawEvent())

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 import wx
 from OpenGL.GL import (
     glClear,
@@ -44,6 +44,9 @@ class Renderer(EditCanvasContainer):
         "_gc_timer",
     )
 
+    _sky_box: Optional[SkyBox]
+    _fake_levels: Optional[LevelGroup]
+
     def __init__(
         self,
         canvas: "EditCanvas",
@@ -66,16 +69,8 @@ class Renderer(EditCanvasContainer):
         )
         self._chunk_generator.register(self._render_world)
 
-        self._fake_levels: LevelGroup = LevelGroup(
-            context_identifier,
-            opengl_resource_pack,
-        )
-        self._chunk_generator.register(self._fake_levels)
-
-        self._sky_box: SkyBox = SkyBox(
-            context_identifier,
-            opengl_resource_pack,
-        )
+        self._fake_levels = None
+        self._sky_box = None
 
         self._draw_timer = wx.Timer(self.canvas)
         self._gc_timer = wx.Timer(self.canvas)
@@ -135,29 +130,6 @@ class Renderer(EditCanvasContainer):
     #     self._resource_pack = JavaResourcePackManager(resource_packs)
     #     for _ in self._create_atlas():
     #         pass
-    #
-    # def _create_atlas(self) -> Generator[float, None, None]:
-    #     """Create and bind the atlas texture."""
-    #     atlas_iter = textureatlas.create_atlas(self._resource_pack.textures)
-    #     try:
-    #         while True:
-    #             yield next(atlas_iter)
-    #     except StopIteration as e:
-    #         texture_atlas, self._texture_bounds, width, height = e.value
-    #     glBindTexture(GL_TEXTURE_2D, self._gl_texture_atlas)
-    #     glTexImage2D(
-    #         GL_TEXTURE_2D,
-    #         0,
-    #         GL_RGBA,
-    #         width,
-    #         height,
-    #         0,
-    #         GL_RGBA,
-    #         GL_UNSIGNED_BYTE,
-    #         texture_atlas,
-    #     )
-    #     glBindTexture(GL_TEXTURE_2D, 0)
-    #     log.info("Finished setting up texture atlas in OpenGL")
 
     @property
     def opengl_resource_pack(self) -> OpenGLResourcePack:
@@ -170,11 +142,22 @@ class Renderer(EditCanvasContainer):
     @property
     def fake_levels(self) -> LevelGroup:
         """Floating levels that are not the main level."""
+        if self._fake_levels is None:
+            self._fake_levels: LevelGroup = LevelGroup(
+                self.canvas.context_identifier,
+                self.opengl_resource_pack,
+            )
+            self._chunk_generator.register(self._fake_levels)
         return self._fake_levels
 
     @property
     def sky_box(self) -> SkyBox:
-        """Floating levels that are not the main level."""
+        """The cube in the distance displaying the sky."""
+        if self._sky_box is None:
+            self._sky_box = SkyBox(
+                self._render_world.context_identifier,
+                self._opengl_resource_pack,
+            )
         return self._sky_box
 
     @property

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Optional, Generator
 import webbrowser
 from threading import Thread
+import traceback
 
 import wx
 
@@ -12,6 +13,7 @@ from amulet_map_editor import log, lang
 from amulet_map_editor.api.framework.programs import BaseProgram
 from amulet_map_editor.api.datatypes import MenuData
 from amulet_map_editor.api.wx.util.key_config import KeyConfigDialog
+from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor.api.wx.ui.simple import SimpleDialog
 from amulet_map_editor.programs.edit.api.canvas.edit_canvas import EditCanvas
 from amulet_map_editor.programs.edit.api.key_config import (
@@ -63,6 +65,7 @@ class EditExtension(wx.Panel, BaseProgram):
     def enable(self):
         if self._canvas is None:
             self._canvas = EditCanvas(self, self._world)
+            self._canvas.Hide()
             self._setup_thread = Thread(target=self._thread_setup)
             self._setup_thread.start()
         else:
@@ -81,43 +84,62 @@ class EditExtension(wx.Panel, BaseProgram):
                 self._temp_msg.SetLabel(arg[1])
             self.Layout()
 
+    def _display_error(self, msg, tb):
+        dialog = TracebackDialog(
+            self,
+            "Exception while setting up canvas",
+            msg,
+            tb,
+        )
+        dialog.ShowModal()
+        dialog.Destroy()
+        self.Destroy()
+
     def _thread_setup(self):
         """
         Setup and enable all the UI elements.
         This can take a while to run so should be done in a new thread.
         Everything in here must be thread safe.
         """
-        self._update_loading(self._canvas.thread_setup())
-        wx.CallAfter(self._post_thread_setup)
+        try:
+            self._update_loading(self._canvas.thread_setup())
+        except Exception as e:
+            wx.CallAfter(self._display_error, str(e), traceback.format_exc())
+            raise e
+        else:
+            wx.CallAfter(self._post_thread_setup)
 
     def _post_thread_setup(self):
         """
         Run any setup that is not thread safe.
         """
-        self._update_loading(self._canvas.post_thread_setup())
-        edit_config: dict = config.get(EDIT_CONFIG_ID, {})
-        self._canvas.camera.perspective_fov = edit_config.get("options", {}).get(
-            "fov", 70.0
-        )
-        if self._canvas.camera.perspective_fov > 180:
-            self._canvas.camera.perspective_fov = 70.0
-        self._canvas.renderer.render_distance = edit_config.get("options", {}).get(
-            "render_distance", 5
-        )
-        self._canvas.camera.rotate_speed = edit_config.get("options", {}).get(
-            "camera_sensitivity", 2.0
-        )
+        try:
+            self._update_loading(self._canvas.post_thread_setup())
+            edit_config: dict = config.get(EDIT_CONFIG_ID, {})
+            self._canvas.camera.perspective_fov = edit_config.get("options", {}).get(
+                "fov", 70.0
+            )
+            if self._canvas.camera.perspective_fov > 180:
+                self._canvas.camera.perspective_fov = 70.0
+            self._canvas.renderer.render_distance = edit_config.get("options", {}).get(
+                "render_distance", 5
+            )
+            self._canvas.camera.rotate_speed = edit_config.get("options", {}).get(
+                "camera_sensitivity", 2.0
+            )
 
-        self._temp_msg = None
-        self._temp_loading_bar = None
-        self._sizer.Clear(True)
-        self._sizer.Add(self._canvas, 1, wx.EXPAND)
-        self._canvas.Show()
-        self._canvas._set_size()
-
-        self.Layout()
-        self._canvas.enable()
-        self._setup_thread = None
+            self._temp_msg = None
+            self._temp_loading_bar = None
+            self._sizer.Clear(True)
+            self._sizer.Add(self._canvas, 1, wx.EXPAND)
+            self._canvas.Show()
+            self._canvas._set_size()
+            self.Layout()
+            wx.CallAfter(self._canvas.enable)  # This must be called after the show handler is run
+            self._setup_thread = None
+        except Exception as e:
+            wx.CallAfter(self._display_error, str(e), traceback.format_exc())
+            raise e
 
     def can_disable(self) -> bool:
         return self._setup_thread is None

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -135,7 +135,9 @@ class EditExtension(wx.Panel, BaseProgram):
             self._canvas.Show()
             self._canvas._set_size()
             self.Layout()
-            wx.CallAfter(self._canvas.enable)  # This must be called after the show handler is run
+            wx.CallAfter(
+                self._canvas.enable
+            )  # This must be called after the show handler is run
             self._setup_thread = None
         except Exception as e:
             wx.CallAfter(self._display_error, str(e), traceback.format_exc())


### PR DESCRIPTION
Reading into OpenGL I found some issues with how we were doing things.
OpenGL functions cannot be called until the window is shown which might be the reason some users are getting errors.
Created a function that runs the first time the window is shown. Moved all the initial OpenGL state setting into this function. Enable is run once this function is done.
Other OpenGL initialisation is moved into the drawing functions which are run after the window is shown for the first time.