### PR TITLE
Fixed a bug in set biome operation

### DIFF
--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/set_biome.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/set_biome.py
@@ -133,9 +133,11 @@ class SetBiome(SimpleOperationPanel):
                     continue
             elif mode == ColumnMode:
                 if chunk.biomes.dimension == BiomesShape.Shape3D:
+                    bounds = world.bounds(dimension)
                     slices = (
                         slice(slices[0].start // 4, math.ceil(slices[0].stop / 4)),
-                        slice(None, None, None),
+                        # TODO this might cause issues with infinite height worlds. The biome handling needs a rewrite
+                        slice(bounds.min_y // 4, math.ceil(bounds.max_y / 4)),
                         slice(slices[2].start // 4, math.ceil(slices[2].stop / 4)),
                     )
                 elif chunk.biomes.dimension == BiomesShape.Shape2D:


### PR DESCRIPTION
The world height was not taken into account meaning only the 0-256 region was set.

The biome logic needs rewriting to better support the various formats and also handle infinite height worlds.
This logic may cause issues if we implement infinite height worlds because it would lead to an infinite amount of memory usage.

Fixes #683 