### PR TITLE
Fixed the goto file panel button being all zeros

### DIFF
--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -158,13 +158,10 @@ class EditCanvas(BaseEditCanvas):
         # call run_operation to acquire it.
         self._edit_lock = RLock()
 
-    def post_thread_setup(self) -> Generator[OperationYieldType, None, None]:
-        yield from super().post_thread_setup()
-        self._file_panel = FilePanel(self)
-        self._canvas_sizer.Add(self._file_panel, 0, wx.EXPAND, 0)
-
     def _init_opengl(self):
         super()._init_opengl()
+        self._file_panel = FilePanel(self)
+        self._canvas_sizer.Add(self._file_panel, 0, wx.EXPAND, 0)
         self._tool_sizer = ToolManagerSizer(self)
         self._canvas_sizer.Add(self._tool_sizer, 1, wx.EXPAND, 0)
 


### PR DESCRIPTION
Moved the creation of the file panel to after the coordinates are set.
Previously it was constructed before the location was set but the event handlers were bound after the location was set.

This was an issue created by https://github.com/Amulet-Team/Amulet-Map-Editor/pull/678