### PR TITLE
Implemented private variable obfuscation and improved the pyinstaller spec file.

### DIFF
--- a/Amulet.spec
+++ b/Amulet.spec
@@ -50,7 +50,10 @@ def _obfuscate(s: str) -> str:
 
 def obfuscate(mod_path: str):
     """Prefix all private variables (_var or self._var) with _{OBFUSCATE_KEY}"""
+    mod_path = os.path.realpath(mod_path)
     for py_path in glob.glob(os.path.join(mod_path, "**", "*.py"), recursive=True):
+        if not os.path.isfile(py_path):
+            continue
         with open(py_path) as f:
             py_code = f.read()
         rel_py_path = os.path.relpath(py_path, mod_path)
@@ -63,7 +66,7 @@ def obfuscate(mod_path: str):
             except OSError:
                 pass
             py_path = os.path.join(mod_path, ob_rel_py_path)
-            os.makedirs(py_path, exist_ok=True)
+            os.makedirs(os.path.dirname(py_path), exist_ok=True)
 
         py_code = _obfuscate(py_code)
         with open(py_path, "w") as f:
@@ -71,7 +74,7 @@ def obfuscate(mod_path: str):
 
 
 obfuscate(AMULET_PATH)
-obfuscate(PYMCT_PATH)
+# obfuscate(PYMCT_PATH)
 obfuscate(MINECRAFT_MODEL_READER)
 obfuscate(AMULET_MAP_EDITOR)
 

--- a/Amulet.spec
+++ b/Amulet.spec
@@ -9,6 +9,9 @@ import sys
 import os
 import glob
 import importlib.util
+import string
+import random
+import re
 
 # pyinstaller moves the current directory to the front
 # We would prefer to find modules in site packages first
@@ -37,6 +40,24 @@ hidden.extend(collect_submodules("OpenGL"))
 hidden.extend(collect_submodules("OpenGL.GL"))
 hidden.extend(collect_submodules("OpenGL.GL.shaders"))
 
+
+OBFUSCATE_KEY = "_" + "".join(random.choices(string.ascii_lowercase, k=10))
+
+
+def obfuscate(mod_path: str):
+    """Prefix all private variables (_var or self._var) with _{OBFUSCATE_KEY}"""
+    for py_path in glob.glob(os.path.join(mod_path, "**", "*.py"), recursive=True):
+        with open(py_path) as f:
+            py_code = f.read()
+        py_code = re.sub(r"(?<![a-zA-Z0-9_])(?P<name>_[a-zA-Z0-9][a-zA-Z0-9_]*)", lambda match: f"{OBFUSCATE_KEY}{match.group('name')}", py_code)
+        with open(py_path, "w") as f:
+            f.write(py_code)
+
+
+obfuscate(AMULET_PATH)
+obfuscate(PYMCT_PATH)
+obfuscate(MINECRAFT_MODEL_READER)
+obfuscate(AMULET_MAP_EDITOR)
 
 a = Analysis(
     [os.path.join(AMULET_MAP_EDITOR, "__main__.py")],

--- a/Amulet.spec
+++ b/Amulet.spec
@@ -8,6 +8,7 @@ from typing import Dict, Tuple, Set
 import sys
 import os
 import glob
+import importlib.util
 
 # pyinstaller moves the current directory to the front
 # We would prefer to find modules in site packages first
@@ -15,17 +16,17 @@ cwd = os.path.normcase(os.path.realpath(os.getcwd()))
 sys.path = [path for path in sys.path if os.path.normcase(os.path.realpath(path)) != cwd]
 sys.path.append(cwd)
 
-import amulet
-import PyMCTranslate
-import minecraft_model_reader
-import amulet_map_editor
-
 sys.modules["FixTk"] = None
 
-AMULET_PATH = amulet.__path__[0]
-PYMCT_PATH = PyMCTranslate.__path__[0]
-MINECRAFT_MODEL_READER = minecraft_model_reader.__path__[0]
-AMULET_MAP_EDITOR = amulet_map_editor.__path__[0]
+
+def get_package_path(mod: str):
+    return os.path.dirname(importlib.util.find_spec(mod).origin)
+
+
+AMULET_PATH = get_package_path("amulet")
+PYMCT_PATH = get_package_path("PyMCTranslate")
+MINECRAFT_MODEL_READER = get_package_path("minecraft_model_reader")
+AMULET_MAP_EDITOR = get_package_path("amulet_map_editor")
 
 
 hidden = []


### PR DESCRIPTION
Improved code finding module paths. No longer need to import the packages.

Added code to obfuscate private variables (variables starting with a single underscore) so that third parties cannot access or edit the private state.