### PR TITLE
Allow for opening maps from the command line

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,21 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+wxpython = "~=4.1"
+numpy = "~=1.17"
+pyopengl = "~=3.0"
+amulet-core = "~=1.7"
+amulet-nbt = "~=1.1"
+pymctranslate = "~=1.1"
+minecraft-resource-pack = "~=1.2"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"
+
+[scripts]
+amulet = "python -m amulet_map_editor"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,196 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "6a5a8631e8df63e1f35803c0990af54874d333b7081bf9fc5b659b5452b99dd0"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "amulet-core": {
+            "hashes": [
+                "sha256:08770c28940b8cbeebed6ae5603866f373bc4f658e307b23c701835dbb106e51",
+                "sha256:16d1601d68df6a8dc09c09a2642f01006ebbf5a93ecbe2d05d8c121f15130097"
+            ],
+            "index": "pypi",
+            "version": "==1.8.1"
+        },
+        "amulet-nbt": {
+            "hashes": [
+                "sha256:120a50df09326f40983ab8ac34b35c0ddfbbcd2d3e6153effc0c969e4c4277d7",
+                "sha256:2899a14154f90f4db50cfd137c9817df497d266de81c8e7e0d0be39af7a416a3",
+                "sha256:2959987110c8b44a14dac01f540bda21a5bbe8635a604b8ff66567c212bc94be",
+                "sha256:301963497fed2ff30601c1d681e0dd7381a712ae8925a92019a5707e0af7cb02",
+                "sha256:6ff6d14ef9eebb6c658beee2bc067d53d5192e680b3435d50b75670fb2071e95",
+                "sha256:aefe46cc9c56762ab1c9aa705a9438241a301cd09b1595cece7794b3ce3d7402",
+                "sha256:c27c3e387c87e59ec8af3f12722624d5fd033480ce0f89ef9d63a83e150c964a",
+                "sha256:de2d578beb3c46cc47cd97fa5e65ce9a8400829c15b387ebcb10349ea0031d63",
+                "sha256:f0f420aa4dcc21c1167f339029cebc154b614c2d463cb7ab903a89ec61635b79"
+            ],
+            "index": "pypi",
+            "version": "==1.2.1"
+        },
+        "minecraft-resource-pack": {
+            "hashes": [
+                "sha256:03157552a8caa66f6bd2cb046d3cc606a9dd5ff22babd6d7dab15f899fa2594e",
+                "sha256:a54dd3c767852080194263449b92df9bd7dd9361f4e8c8300ca661e9f0d30040"
+            ],
+            "index": "pypi",
+            "version": "==1.2.8"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:092f5e6025813e64ad6d1b52b519165d08c730d099c114a9247c9bb635a2a450",
+                "sha256:196cd074c3f97c4121601790955f915187736f9cf458d3ee1f1b46aff2b1ade0",
+                "sha256:1c29b44905af288b3919803aceb6ec7fec77406d8b08aaa2e8b9e63d0fe2f160",
+                "sha256:2b2da66582f3a69c8ce25ed7921dcd8010d05e59ac8d89d126a299be60421171",
+                "sha256:5043bcd71fcc458dfb8a0fc5509bbc979da0131b9d08e3d5f50fb0bbb36f169a",
+                "sha256:58bfd40eb478f54ff7a5710dd61c8097e169bc36cc68333d00a9bcd8def53b38",
+                "sha256:79a506cacf2be3a74ead5467aee97b81fca00c9c4c8b3ba16dbab488cd99ba10",
+                "sha256:94b170b4fa0168cd6be4becf37cb5b127bd12a795123984385b8cd4aca9857e5",
+                "sha256:97a76604d9b0e79f59baeca16593c711fddb44936e40310f78bfef79ee9a835f",
+                "sha256:98e8e0d8d69ff4d3fa63e6c61e8cfe2d03c29b16b58dbef1f9baa175bbed7860",
+                "sha256:ac86f407873b952679f5f9e6c0612687e51547af0e14ddea1eedfcb22466babd",
+                "sha256:ae8adff4172692ce56233db04b7ce5792186f179c415c37d539c25de7298d25d",
+                "sha256:bd3fa4fe2e38533d5336e1272fc4e765cabbbde144309ccee8675509d5cd7b05",
+                "sha256:d0d2094e8f4d760500394d77b383a1b06d3663e8892cdf5df3c592f55f3bff66",
+                "sha256:d54b3b828d618a19779a84c3ad952e96e2c2311b16384e973e671aa5be1f6187",
+                "sha256:d6ca8dabe696c2785d0c8c9b0d8a9b6e5fdbe4f922bde70d57fa1a2848134f95",
+                "sha256:d8cc87bed09de55477dba9da370c1679bd534df9baa171dd01accbb09687dac3",
+                "sha256:f0f18804df7370571fb65db9b98bf1378172bd4e962482b857e612d1fec0f53e",
+                "sha256:f1d88ef79e0a7fa631bb2c3dda1ea46b32b1fe614e10fedd611d3d5398447f2f",
+                "sha256:f9c3fc2adf67762c9fe1849c859942d23f8d3e0bee7b5ed3d4a9c3eeb50a2f07",
+                "sha256:fc431493df245f3c627c0c05c2bd134535e7929dbe2e602b80e42bf52ff760bc",
+                "sha256:fe8b9683eb26d2c4d5db32cd29b38fdcf8381324ab48313b5b69088e0e355379"
+            ],
+            "index": "pypi",
+            "version": "==1.23.0"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:088df396b047477dd1bbc7de6e22f58400dae2f21310d9e2ec2933b2ef7dfa4f",
+                "sha256:09e67ef6e430f90caa093528bd758b0616f8165e57ed8d8ce014ae32df6a831d",
+                "sha256:0b4d5ad2cd3a1f0d1df882d926b37dbb2ab6c823ae21d041b46910c8f8cd844b",
+                "sha256:0b525a356680022b0af53385944026d3486fc8c013638cf9900eb87c866afb4c",
+                "sha256:1d4331aeb12f6b3791911a6da82de72257a99ad99726ed6b63f481c0184b6fb9",
+                "sha256:20d514c989fa28e73a5adbddd7a171afa5824710d0ab06d4e1234195d2a2e546",
+                "sha256:2b291cab8a888658d72b575a03e340509b6b050b62db1f5539dd5cd18fd50578",
+                "sha256:3f6c1716c473ebd1649663bf3b42702d0d53e27af8b64642be0dd3598c761fb1",
+                "sha256:42dfefbef90eb67c10c45a73a9bc1599d4dac920f7dfcbf4ec6b80cb620757fe",
+                "sha256:488f3383cf5159907d48d32957ac6f9ea85ccdcc296c14eca1a4e396ecc32098",
+                "sha256:4d45dbe4b21a9679c3e8b3f7f4f42a45a7d3ddff8a4a16109dff0e1da30a35b2",
+                "sha256:53c27bd452e0f1bc4bfed07ceb235663a1df7c74df08e37fd6b03eb89454946a",
+                "sha256:55e74faf8359ddda43fee01bffbc5bd99d96ea508d8a08c527099e84eb708f45",
+                "sha256:59789a7d06c742e9d13b883d5e3569188c16acb02eeed2510fd3bfdbc1bd1530",
+                "sha256:5b650dbbc0969a4e226d98a0b440c2f07a850896aed9266b6fedc0f7e7834108",
+                "sha256:66daa16952d5bf0c9d5389c5e9df562922a59bd16d77e2a276e575d32e38afd1",
+                "sha256:6e760cf01259a1c0a50f3c845f9cad1af30577fd8b670339b1659c6d0e7a41dd",
+                "sha256:7502539939b53d7565f3d11d87c78e7ec900d3c72945d4ee0e2f250d598309a0",
+                "sha256:769a7f131a2f43752455cc72f9f7a093c3ff3856bf976c5fb53a59d0ccc704f6",
+                "sha256:7c150dbbb4a94ea4825d1e5f2c5501af7141ea95825fadd7829f9b11c97aaf6c",
+                "sha256:8844217cdf66eabe39567118f229e275f0727e9195635a15e0e4b9227458daaf",
+                "sha256:8a66fe50386162df2da701b3722781cbe90ce043e7d53c1fd6bd801bca6b48d4",
+                "sha256:9370d6744d379f2de5d7fa95cdbd3a4d92f0b0ef29609b4b1687f16bc197063d",
+                "sha256:937a54e5694684f74dcbf6e24cc453bfc5b33940216ddd8f4cd8f0f79167f765",
+                "sha256:9c857532c719fb30fafabd2371ce9b7031812ff3889d75273827633bca0c4602",
+                "sha256:a4165205a13b16a29e1ac57efeee6be2dfd5b5408122d59ef2145bc3239fa340",
+                "sha256:b3fe2ff1e1715d4475d7e2c3e8dabd7c025f4410f79513b4ff2de3d51ce0fa9c",
+                "sha256:b6617221ff08fbd3b7a811950b5c3f9367f6e941b86259843eab77c8e3d2b56b",
+                "sha256:b761727ed7d593e49671d1827044b942dd2f4caae6e51bab144d4accf8244a84",
+                "sha256:baf3be0b9446a4083cc0c5bb9f9c964034be5374b5bc09757be89f5d2fa247b8",
+                "sha256:c17770a62a71718a74b7548098a74cd6880be16bcfff5f937f900ead90ca8e92",
+                "sha256:c67db410508b9de9c4694c57ed754b65a460e4812126e87f5052ecf23a011a54",
+                "sha256:d78ca526a559fb84faaaf84da2dd4addef5edb109db8b81677c0bb1aad342601",
+                "sha256:e9ed59d1b6ee837f4515b9584f3d26cf0388b742a11ecdae0d9237a94505d03a",
+                "sha256:f054b020c4d7e9786ae0404278ea318768eb123403b18453e28e47cdb7a0a4bf",
+                "sha256:f372d0f08eff1475ef426344efe42493f71f377ec52237bf153c5713de987251",
+                "sha256:f3f6a6034140e9e17e9abc175fc7a266a6e63652028e157750bd98e804a8ed9a",
+                "sha256:ffde4c6fabb52891d81606411cbfaf77756e3b561b566efd270b3ed3791fde4e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==9.1.1"
+        },
+        "portalocker": {
+            "hashes": [
+                "sha256:a648ad761b8ea27370cb5915350122cd807b820d2193ed5c9cc28f163df637f4",
+                "sha256:b092f48e1e30a234ab3dd1cfd44f2f235e8a41f4e310e463fc8d6798d1c3c235"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.4.0"
+        },
+        "pymctranslate": {
+            "hashes": [
+                "sha256:76ea2963eb5836a8cdaa79968ef6392a332ff78f0ade69e73c84668cd25fdd84",
+                "sha256:fb728946130ba435e55e9555b4a5d0550f2431a232b20259669f469c62fbcabd"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
+        },
+        "pyopengl": {
+            "hashes": [
+                "sha256:57c597d989178e1413002df6b923619f6d29807501dece1c60cc6f12c0c8e8a7",
+                "sha256:8ea6c8773927eda7405bffc6f5bb93be81569a7b05c8cac50cd94e969dce5e27",
+                "sha256:a7139bc3e15d656feae1f7e3ef68c799941ed43fadc78177a23db7e946c20738"
+            ],
+            "index": "pypi",
+            "version": "==3.1.6"
+        },
+        "pywin32": {
+            "hashes": [
+                "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc",
+                "sha256:30c53d6ce44c12a316a06c153ea74152d3b1342610f1b99d40ba2795e5af0269",
+                "sha256:3c7bacf5e24298c86314f03fa20e16558a4e4138fc34615d7de4070c23e65af3",
+                "sha256:4f32145913a2447736dad62495199a8e280a77a0ca662daa2332acf849f0be48",
+                "sha256:7ffa0c0fa4ae4077e8b8aa73800540ef8c24530057768c3ac57c609f99a14fd4",
+                "sha256:94037b5259701988954931333aafd39cf897e990852115656b014ce72e052e96",
+                "sha256:bb2ea2aa81e96eee6a6b79d87e1d1648d3f8b87f9a64499e0b92b30d141e76df",
+                "sha256:be253e7b14bc601718f014d2832e4c18a5b023cbe72db826da63df76b77507a1",
+                "sha256:cbbe34dad39bdbaa2889a424d28752f1b4971939b14b1bb48cbf0182a3bcfc43",
+                "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9",
+                "sha256:d3ee45adff48e0551d1aa60d2ec066fec006083b791f5c3527c40cd8aefac71f",
+                "sha256:de9827c23321dcf43d2f288f09f3b6d772fee11e809015bdae9e69fe13213988",
+                "sha256:ead865a2e179b30fb717831f73cf4373401fc62fbc3455a0889a7ddac848f83e",
+                "sha256:f64c0377cf01b61bd5e76c25e1480ca8ab3b73f0c4add50538d332afdf8f69c5"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==304"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        },
+        "wxpython": {
+            "hashes": [
+                "sha256:00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528",
+                "sha256:07aed697e86904eb6bd63956a3eb792eb54139ddec3ee95f129340973bdcdc54",
+                "sha256:15adf25d8353e196e1258c9d3dda353b67c877fb16519b21c6f64d5efbb9798e",
+                "sha256:4fde25e97a85b681ee1c76d15b8ee802661d9af4a615d07dc35374b62225d467",
+                "sha256:64933480eff036d50754ef46496247510b9f0a17eb24d7a8079188c868c5b978",
+                "sha256:84c3d5c7a43e1face86569e0832a526c31ad4a43d0448bef2fec6ce08de0f699",
+                "sha256:a3d699d20826eae5130e117dd0a9024ea9f5e6677669f1e2874a68a96a979272",
+                "sha256:bbd3e9a6f7bde3b72a7159584a760976f4cbaafba4315c7ea8b29e6c3731fa50",
+                "sha256:daf6c3e732954fd56ea50942bd698a6c273c206f424bacd929bf1419148d048f",
+                "sha256:db057f9c7144ecdef21ed2da683fd9f2dfd7d897d4158626de49d523dbb82945",
+                "sha256:e132144ac4b05092d18ae63c335571f338d8da82be1c126d2d84c70d43cfcf28",
+                "sha256:e8170353bc1004574552a5b121251cc859b68d9cf6f09118dd9be48422448304",
+                "sha256:f03d00c25db206d294ba99f15714368e02416b67be12bd8714b8268870e3b155"
+            ],
+            "index": "pypi",
+            "version": "==4.1.1"
+        }
+    },
+    "develop": {}
+}

--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -76,11 +76,11 @@ class AmuletUI(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self._on_close_app)
         self.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._page_change)
-        
+
         if len(argv) == 2:
             if exists(argv[1]):
                 self._open_world(argv[1])
-        
+
         if update_check:
             self.Bind(
                 update_check.EVT_UPDATE_CHECK,

--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -13,6 +13,9 @@ from .pages import AmuletMainMenu, BasePageUI
 from amulet_map_editor.api import image
 from amulet_map_editor.api.wx.util.ui_preferences import preserve_ui_preferences
 
+from sys import argv
+from os.path import exists
+
 # Uses a conditional so if this breaks a build, we can just delete the file and it will skip the check
 try:
     from amulet_map_editor.api.framework import update_check
@@ -73,7 +76,11 @@ class AmuletUI(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self._on_close_app)
         self.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._page_change)
-
+        
+        if len(argv) == 2:
+            if exists(argv[1]):
+                self._open_world(argv[1])
+        
         if update_check:
             self.Bind(
                 update_check.EVT_UPDATE_CHECK,

--- a/amulet_map_editor/api/opengl/camera/camera.py
+++ b/amulet_map_editor/api/opengl/camera/camera.py
@@ -90,7 +90,7 @@ class Camera(CanvasContainer):
         self._projection_mode = Projection.PERSPECTIVE
         self._fov = [100.0, 70.0]
         self._clipping: List[Tuple[float, float]] = [
-            (-(10**5), 10**5),
+            (-(10 ** 5), 10 ** 5),
             (0.1, 10000.0),
         ]
         self._aspect_ratio = 4 / 3

--- a/amulet_map_editor/api/opengl/textureatlas.py
+++ b/amulet_map_editor/api/opengl/textureatlas.py
@@ -298,7 +298,7 @@ def create_atlas_iter(
             width = max(f.width, width)
             pixels += f.height * f.width
 
-    size = max(height, width, 1 << (math.ceil(pixels**0.5) - 1).bit_length())
+    size = max(height, width, 1 << (math.ceil(pixels ** 0.5) - 1).bit_length())
 
     atlas_created = False
     atlas = None

--- a/amulet_map_editor/api/wx/ui/select_world.py
+++ b/amulet_map_editor/api/wx/ui/select_world.py
@@ -1,8 +1,7 @@
 import os
-import os.path
 import wx
 import glob
-from sys import platform, argv
+from sys import platform
 from typing import List, Dict, Tuple, Callable, TYPE_CHECKING
 import traceback
 
@@ -322,10 +321,6 @@ class WorldSelectAndRecentUI(wx.Panel):
         bottom_sizer.Add(right_sizer, 1, wx.EXPAND)
         self._recent_worlds = RecentWorldUI(self, self._update_recent)
         right_sizer.Add(self._recent_worlds, 1, wx.EXPAND, 5)
-        if len(sys.argv) == 2:
-            if os.path.exists(sys.argv[1]):
-                self._recent_worlds.rebuild(sys.argv[1])
-                self._open_world_callback(sys.argv[1])
 
     def _update_recent(self, path):
         self._recent_worlds.rebuild(path)

--- a/amulet_map_editor/api/wx/ui/select_world.py
+++ b/amulet_map_editor/api/wx/ui/select_world.py
@@ -1,7 +1,8 @@
 import os
+import os.path
 import wx
 import glob
-from sys import platform
+from sys import platform, argv
 from typing import List, Dict, Tuple, Callable, TYPE_CHECKING
 import traceback
 
@@ -321,6 +322,10 @@ class WorldSelectAndRecentUI(wx.Panel):
         bottom_sizer.Add(right_sizer, 1, wx.EXPAND)
         self._recent_worlds = RecentWorldUI(self, self._update_recent)
         right_sizer.Add(self._recent_worlds, 1, wx.EXPAND, 5)
+        if len(sys.argv) == 2:
+            if os.path.exists(sys.argv[1]):
+                self._recent_worlds.rebuild(sys.argv[1])
+                self._open_world_callback(sys.argv[1])
 
     def _update_recent(self, path):
         self._recent_worlds.rebuild(path)

--- a/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
@@ -389,13 +389,13 @@ class BlockSelectionBehaviour(PointerBehaviour):
         if self._pointer_moved:
             if self.canvas.camera.projection_mode == Projection.TOP_DOWN:
                 camera = self.canvas.camera.location
-                camera = (camera[0], 10**9, camera[2])
+                camera = (camera[0], 10 ** 9, camera[2])
                 look_vector = self.look_vector()
                 selection_group, box_index, max_distance = self._get_box_hit_data(
                     camera, look_vector
                 )
                 location, hit_block = self.closest_block_2d(
-                    int(10**9 - min(max_distance, 10**9)) + 1
+                    int(10 ** 9 - min(max_distance, 10 ** 9)) + 1
                 )
             else:
                 (

--- a/amulet_map_editor/programs/edit/api/behaviour/raycast_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/raycast_behaviour.py
@@ -206,7 +206,7 @@ class RaycastBehaviour(BaseBehaviour):
 
         for axis in range(3):
             vector = vectors[axis]
-            vector_size = numpy.sum(vector**2) ** 0.5
+            vector_size = numpy.sum(vector ** 2) ** 0.5
             # move the start position to the block edge behind the vector
             if vector[axis] > 0:
                 initial_offset = -vector * start[axis]
@@ -214,7 +214,7 @@ class RaycastBehaviour(BaseBehaviour):
                 initial_offset = -vector * (1 - start[axis])
 
             block_count = (
-                max_distance + numpy.sum(initial_offset**2) ** 0.5 - 0.001
+                max_distance + numpy.sum(initial_offset ** 2) ** 0.5 - 0.001
             ) // vector_size
 
             if block_count:

--- a/amulet_map_editor/programs/edit/plugins/tools/chunk.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/chunk.py
@@ -138,7 +138,7 @@ class ChunkTool(wx.BoxSizer, DefaultBaseToolUI):
 
     def disable(self):
         super().disable()
-        self.canvas.camera.orthographic_clipping = -(10**5), 10**5
+        self.canvas.camera.orthographic_clipping = -(10 ** 5), 10 ** 5
 
     def _on_update_clipping(self, evt):
         self._update_clipping()
@@ -262,7 +262,7 @@ class ChunkTool(wx.BoxSizer, DefaultBaseToolUI):
             if depth_state:
                 glDisable(GL_DEPTH_TEST)
             clip = self.canvas.camera.orthographic_clipping
-            self.canvas.camera.orthographic_clipping = -(10**5), 10**5
+            self.canvas.camera.orthographic_clipping = -(10 ** 5), 10 ** 5
             self._selection.draw()
             self.canvas.camera.orthographic_clipping = clip
             if depth_state:


### PR DESCRIPTION
This PR adds support for
- Drag-n-dropping worlds onto Amulet
- Opening worlds from the CLI (i.e., allowing apps like [MultiMC](https://github.com/MultiMC/Launcher/issues/3713) to open worlds automatically)

Todo:
- [x] Test latest commit
- [x] Check for accidentally committed files 
- [x] Run black 