### PR TITLE
Updated save_picker & open_picker with new options

### DIFF
--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -173,7 +173,9 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         else:
             path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(self, path=path, style=wx.FLP_SAVE | wx.FLP_USE_TEXTCTRL)
+        option = wx.FilePickerCtrl(
+            self, path=path, style=wx.FLP_SAVE | wx.FLP_USE_TEXTCTRL
+        )
         sizer.Add(option)
         self._options[option_name] = option
 
@@ -185,7 +187,9 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         else:
             path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(self, path=path, style=wx.FLP_OPEN | wx.FLP_USE_TEXTCTRL)
+        option = wx.FilePickerCtrl(
+            self, path=path, style=wx.FLP_OPEN | wx.FLP_USE_TEXTCTRL
+        )
         sizer.Add(option)
         self._options[option_name] = option
 

--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -166,14 +166,26 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         self._options[option_name] = option
 
     def _create_file_save_picker(self, option_name: str, options: Sequence):
+        if options:
+            path, *options = options
+            if not isinstance(path, str):
+                path = ""
+        else:
+            path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(self, style=wx.FLP_SAVE | wx.FLP_USE_TEXTCTRL)
+        option = wx.FilePickerCtrl(self, path=path, style=wx.FLP_SAVE | wx.FLP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
 
     def _create_file_open_picker(self, option_name: str, options: Sequence):
+        if options:
+            path, *options = options
+            if not isinstance(path, str):
+                path = ""
+        else:
+            path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(self, style=wx.FLP_OPEN | wx.FLP_USE_TEXTCTRL)
+        option = wx.FilePickerCtrl(self, path=path, style=wx.FLP_OPEN | wx.FLP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
 


### PR DESCRIPTION
The save_picker & open_picker methods now have option capabilities for setting default paths if supplied, if none are supplied will set to a blank string which was the previous behavior.

- Code by gentlegiantJGC, implemented by StealthyX