### PR TITLE
Updated _create_directory_picker with new option

### DIFF
--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -201,9 +201,7 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         else:
             path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.DirPickerCtrl(
-            self, path=path, style=wx.DIRP_USE_TEXTCTRL
-        )
+        option = wx.DirPickerCtrl(self, path=path, style=wx.DIRP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
 

--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -194,8 +194,16 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         self._options[option_name] = option
 
     def _create_directory_picker(self, option_name: str, options: Sequence):
+        if options:
+            path, *options = options
+            if not isinstance(path, str):
+                path = ""
+        else:
+            path = ""
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.DirPickerCtrl(self, style=wx.DIRP_USE_TEXTCTRL)
+        option = wx.DirPickerCtrl(
+            self, path=path, style=wx.DIRP_USE_TEXTCTRL
+        )
         sizer.Add(option)
         self._options[option_name] = option
 


### PR DESCRIPTION
The directory method now has an option for setting the default path if supplied, if none are supplied will be set to a blank string which was the previous behavior.

Code by gentlegiantJGC, implemented by StealthyX

- Sorry, missed this in the last pull request.