### PR TITLE
Added a new simple UI API button type

### DIFF
--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -55,6 +55,7 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
             "file_open": self._create_file_open_picker,
             "file_save": self._create_file_save_picker,
             "directory": self._create_directory_picker,
+            "button": self._create_button,
         }
         for option_name, option in options.items():
             if not (isinstance(option, (list, tuple)) and option):
@@ -204,6 +205,25 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         option = wx.DirPickerCtrl(self, path=path, style=wx.DIRP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
+
+    def _create_button(self, option_name: str, options: Sequence):
+        def _get_on_click(self, callback):
+            def _on_click(event):
+                return callback()
+
+            return _on_click
+
+        if options:
+            button_name, callback, *options = options
+            if not isinstance(button_name, str):
+                button_name = ""
+        else:
+            button_name = ""
+
+        button = wx.Button(self, wx.ID_ANY, button_name)
+        button.Bind(wx.EVT_BUTTON, _get_on_click(self, callback))
+        sizer = self._create_horizontal_options_sizer(option_name)
+        sizer.Add(button)
 
     def _get_values(self) -> Dict[str, Any]:
         options = {}

--- a/amulet_map_editor/programs/edit/plugins/operations/examples/3_fixed_function_pipeline.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/examples/3_fixed_function_pipeline.py
@@ -7,6 +7,11 @@ from amulet.api.selection import SelectionGroup
 from amulet.api.level import BaseLevel
 from amulet.api.data_types import Dimension
 
+# function example for the Button input example.
+def function_name():
+    print("you have clicked a button.")
+
+
 operation_options = {  # options is a dictionary where the key is the description shown to the user and the value describes how to build the UI
     "Text Label": ["label"],  # This will just be a label
     # bool examples  https://wxpython.org/Phoenix/docs/html/wx.CheckBox.html
@@ -55,7 +60,10 @@ operation_options = {  # options is a dictionary where the key is the descriptio
     # OS examples
     "File Open picker": ["file_open"],  # UI to pick an existing file
     "File Save picker": ["file_save"],  # UI to pick a file to save to
-    "Folder picker": ["directory"],  # UI to pick a directory
+    "Folder picker": ["directory"],  # UI to pick a directory,
+    # This will be a button input and it will run the function_name()
+    # function when clicked by the user.
+    "Button input": ["button", "button name", function_name],
 }
 
 


### PR DESCRIPTION
Added a new simple UI API button type,

The goal of this commit was to add a button type for the simple UI interface as it was missing this option by adding _create_button() which creates a button element with the button name arg as a string and the callback function you pass to it.

When you pass the function as the second arg, it will run the function that is in your plugin, the use cases include creating open directory buttons for custom directories, custom data file save locations, etc.

I finally got black working and ran it on the file before making the push request.