### PR TITLE
Added new UI button option with examples.

### DIFF
--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -207,21 +207,17 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         self._options[option_name] = option
 
     def _create_button(self, option_name: str, options: Sequence):
-        def _get_on_click(self, callback):
-            def _on_click(event):
-                return callback()
-
-            return _on_click
-
         if options:
             button_name, callback, *options = options
             if not isinstance(button_name, str):
                 button_name = ""
         else:
+            def callback():
+                pass
             button_name = ""
 
         button = wx.Button(self, wx.ID_ANY, button_name)
-        button.Bind(wx.EVT_BUTTON, _get_on_click(self, callback))
+        button.Bind(wx.EVT_BUTTON, lambda evt: callback())
         sizer = self._create_horizontal_options_sizer(option_name)
         sizer.Add(button)
 

--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -1,6 +1,7 @@
 import wx
 from typing import Callable, Dict, Any, TYPE_CHECKING, Sequence
 import logging
+import inspect
 
 from amulet_map_editor.api.wx.util.validators import IntValidator
 
@@ -69,7 +70,7 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
             except Exception as e:
                 log.exception(e)
 
-    def _create_label(self, option_name: str, *options):
+    def _create_label(self, option_name: str):
         label = wx.StaticText(self, label=option_name)
         self._options_sizer.Add(label, 0, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 5)
 
@@ -80,148 +81,104 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         self._options_sizer.Add(sizer, 0, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 5)
         return sizer
 
-    def _create_bool(self, option_name: str, *options):
-        if options and not isinstance(options[0], bool):
-            return
+    def _create_bool(self, option_name: str, value: bool = False):
+        if not isinstance(value, bool):
+            raise TypeError("value must be a bool")
         sizer = self._create_horizontal_options_sizer(option_name)
         option = wx.CheckBox(self)
         sizer.Add(option)
-        if options:
-            option.SetValue(options[0])
+        option.SetValue(value)
         self._options[option_name] = option
 
-    def _create_int(self, option_name: str, *options):
-        if len(options) in {0, 1, 3} and all(isinstance(o, int) for o in options):
-            sizer = self._create_horizontal_options_sizer(option_name)
-            if len(options) == 0:
-                option = wx.SpinCtrl(
-                    self,
-                    min=-30_000_000,
-                    max=30_000_000,
-                    initial=0,
-                )
-            elif len(options) == 1:
-                option = wx.SpinCtrl(
-                    self,
-                    min=-30_000_000,
-                    max=30_000_000,
-                    initial=options[0],
-                )
-            elif len(options) == 3:
-                option = wx.SpinCtrl(
-                    self,
-                    min=min(options[1:3]),
-                    max=max(options[1:3]),
-                    initial=options[0],
-                )
-            else:
-                return  # should not get here
-            option.SetValidator(IntValidator())
-            sizer.Add(option)
-            self._options[option_name] = option
-
-    def _create_float(self, option_name: str, *options):
-        if len(options) in {0, 1, 3} and all(
-            isinstance(o, (int, float)) for o in options
+    def _create_int(
+        self, option_name: str, initial=0, min_val=-30_000_000, max_val=30_000_000
+    ):
+        if not (
+            isinstance(initial, int)
+            and isinstance(min_val, int)
+            and isinstance(max_val, int)
         ):
-            sizer = self._create_horizontal_options_sizer(option_name)
-            if len(options) == 0:
-                option = wx.SpinCtrlDouble(
-                    self,
-                    min=-30_000_000,
-                    max=30_000_000,
-                    initial=0,
-                )
-            elif len(options) == 1:
-                option = wx.SpinCtrlDouble(
-                    self,
-                    min=-30_000_000,
-                    max=30_000_000,
-                    initial=options[0],
-                )
-            elif len(options) == 3:
-                option = wx.SpinCtrlDouble(
-                    self,
-                    min=min(options[1:3]),
-                    max=max(options[1:3]),
-                    initial=options[0],
-                )
-            else:
-                return  # should not get here
-            sizer.Add(option)
-            self._options[option_name] = option
+            raise TypeError("Input value must be int")
+        sizer = self._create_horizontal_options_sizer(option_name)
+        option = wx.SpinCtrl(
+            self,
+            min=min(min_val, max_val),
+            max=max(min_val, max_val),
+            initial=initial,
+        )
+        option.SetValidator(IntValidator())
+        sizer.Add(option)
+        self._options[option_name] = option
 
-    def _create_string(self, option_name: str, *options):
-        if options and not isinstance(options[0], str):
-            return
+    def _create_float(
+        self, option_name: str, initial=0, min_val=-30_000_000, max_val=30_000_000
+    ):
+        if not (
+            isinstance(initial, (int, float))
+            and isinstance(min_val, (int, float))
+            and isinstance(max_val, (int, float))
+        ):
+            raise TypeError("Input value must be int or float")
+        sizer = self._create_horizontal_options_sizer(option_name)
+        option = wx.SpinCtrlDouble(
+            self,
+            min=min(min_val, max_val),
+            max=max(min_val, max_val),
+            initial=initial,
+        )
+        sizer.Add(option)
+        self._options[option_name] = option
+
+    def _create_string(self, option_name: str, value: str = ""):
+        if not isinstance(value, str):
+            raise TypeError("value must be a string")
         sizer = self._create_horizontal_options_sizer(option_name)
         option = wx.TextCtrl(self)
         sizer.Add(option)
-        if options:
-            option.SetValue(options[0])
+        option.SetValue(value)
         self._options[option_name] = option
 
-    def _create_str_choice(self, option_name: str, *options):
-        if not (options and all(isinstance(o, str) for o in options)):
+    def _create_str_choice(self, option_name: str, *choices: str):
+        if not (choices and all(isinstance(o, str) for o in choices)):
             return
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.Choice(self, choices=options)
+        option = wx.Choice(self, choices=choices)
         option.SetSelection(0)
         sizer.Add(option)
         self._options[option_name] = option
 
-    def _create_file_save_picker(self, option_name: str, *options):
-        if options:
-            path, *options = options
-            if not isinstance(path, str):
-                path = ""
-        else:
-            path = ""
+    def _create_file_picker(self, option_name: str, path: str, mode):
+        if not isinstance(path, str):
+            raise TypeError("path must be a string")
         sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(
-            self, path=path, style=wx.FLP_SAVE | wx.FLP_USE_TEXTCTRL
-        )
+        option = wx.FilePickerCtrl(self, path=path, style=mode | wx.FLP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
 
-    def _create_file_open_picker(self, option_name: str, *options):
-        if options:
-            path, *options = options
-            if not isinstance(path, str):
-                path = ""
-        else:
-            path = ""
-        sizer = self._create_horizontal_options_sizer(option_name)
-        option = wx.FilePickerCtrl(
-            self, path=path, style=wx.FLP_OPEN | wx.FLP_USE_TEXTCTRL
-        )
-        sizer.Add(option)
-        self._options[option_name] = option
+    def _create_file_save_picker(self, option_name: str, path: str = ""):
+        self._create_file_picker(option_name, path, wx.FLP_SAVE)
 
-    def _create_directory_picker(self, option_name: str, *options):
-        if options:
-            path, *options = options
-            if not isinstance(path, str):
-                path = ""
-        else:
-            path = ""
+    def _create_file_open_picker(self, option_name: str, path: str = ""):
+        self._create_file_picker(option_name, path, wx.FLP_OPEN)
+
+    def _create_directory_picker(self, option_name: str, path: str = ""):
+        if not isinstance(path, str):
+            raise TypeError("path must be a string")
         sizer = self._create_horizontal_options_sizer(option_name)
         option = wx.DirPickerCtrl(self, path=path, style=wx.DIRP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
 
-    def _create_button(self, option_name: str, *options):
-        if options:
-            button_name, callback, *options = options
-            if not isinstance(button_name, str):
-                button_name = ""
-        else:
-
-            def callback():
-                pass
-
-            button_name = ""
-
+    def _create_button(
+        self,
+        option_name: str,
+        button_name: str = "",
+        callback: Callable[[], Any] = lambda: None,
+    ):
+        if not isinstance(button_name, str):
+            raise TypeError("button_name must be a string")
+        if inspect.signature(callback).parameters:
+            raise TypeError("callback does not take any arguments")
         button = wx.Button(self, wx.ID_ANY, button_name)
         button.Bind(wx.EVT_BUTTON, lambda evt: callback())
         sizer = self._create_horizontal_options_sizer(option_name)

--- a/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
+++ b/amulet_map_editor/programs/edit/api/operations/ui/fixed_pipeline.py
@@ -55,6 +55,7 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
             "file_open": self._create_file_open_picker,
             "file_save": self._create_file_save_picker,
             "directory": self._create_directory_picker,
+            "button": self._create_button,
         }
         for option_name, option in options.items():
             if not (isinstance(option, (list, tuple)) and option):
@@ -204,6 +205,25 @@ class FixedFunctionUI(wx.Panel, DefaultOperationUI):
         option = wx.DirPickerCtrl(self, path=path, style=wx.DIRP_USE_TEXTCTRL)
         sizer.Add(option)
         self._options[option_name] = option
+
+    def _create_button(self, option_name: str, options: Sequence):
+        def _get_on_click(self, callback):
+            def _on_click(event):
+                return callback()
+
+            return _on_click
+
+        if options:
+            button_name, callback, *options = options
+            if not isinstance(button_name, str):
+                button_name = ""
+        else:
+            button_name = ""
+
+        button = wx.Button(self, wx.ID_ANY, button_name)
+        button.Bind(wx.EVT_BUTTON, _get_on_click(self, callback))
+        sizer = self._create_horizontal_options_sizer(option_name)
+        sizer.Add(button)
 
     def _get_values(self) -> Dict[str, Any]:
         options = {}

--- a/amulet_map_editor/programs/edit/plugins/operations/examples/3_fixed_function_pipeline.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/examples/3_fixed_function_pipeline.py
@@ -7,6 +7,11 @@ from amulet.api.selection import SelectionGroup
 from amulet.api.level import BaseLevel
 from amulet.api.data_types import Dimension
 
+# function example for the Button input.
+def function_name():
+    print("you have clicked a button.")
+
+
 operation_options = {  # options is a dictionary where the key is the description shown to the user and the value describes how to build the UI
     "Text Label": ["label"],  # This will just be a label
     # bool examples  https://wxpython.org/Phoenix/docs/html/wx.CheckBox.html
@@ -53,9 +58,14 @@ operation_options = {  # options is a dictionary where the key is the descriptio
     # string choice examples  https://wxpython.org/Phoenix/docs/html/wx.Choice.html
     "Text choice": ["str_choice", "choice 1", "choice 2", "choice 3"],
     # OS examples
-    "File Open picker": ["file_open"],  # UI to pick an existing file
-    "File Save picker": ["file_save"],  # UI to pick a file to save to
-    "Folder picker": ["directory"],  # UI to pick a directory
+    "File Open picker": ["file_open"],  # UI to pick an existing file, will be blank
+    "File Save picker": ["file_save"],  # UI to pick a file to save to, will be blank
+    "Folder picker": ["directory"],  # UI to pick a directory, will be blank
+    "File Open picker": ["file_open", path],  # UI to pick an existing file with a path
+    "File Save picker": ["file_save", path],  # UI to pick a file to save to with a path
+    "Folder picker": ["directory", path],  # UI to pick a directory with a path
+    # UI to add a button and it will run the function_name() when clicked
+    "Button input": ["button", "button name", function_name],
 }
 
 


### PR DESCRIPTION
Added a new UI button option with an example, I also have done the due diligence to update the examples in 3_fixed_function_pipeline.py

Added a new private function _create_button() that adds a new button UI type for the simple plugin UI API.
The first argument is the "button name", and the second argument is the function to call as an event when the button is clicked/pressed by the user.

#custom function you want to run from the button click event.
def function_name():
    print("you have clicked a button.")

#button input type with two arguments.
operation_options = {
    "Button input": ["button", "button name", function_name]
}


