### PR TITLE
Workaround for Pillow bug

### DIFF
--- a/amulet_map_editor/api/opengl/resource_pack/resource_pack.py
+++ b/amulet_map_editor/api/opengl/resource_pack/resource_pack.py
@@ -141,7 +141,7 @@ class OpenGLResourcePack:
                         json.dump((mod_time, bounds), f)
 
             self._image_width, self._image_height = atlas.size
-            self._image = numpy.asarray(atlas, numpy.uint8).ravel()
+            self._image = numpy.array(atlas, numpy.uint8).ravel()
             self._texture_bounds = bounds
 
     def _setup_texture(self, context_id: str):


### PR DESCRIPTION
There is a bug in Pillow's Image.__array__ method where it cannot take a dtype as input. Switched to numpy.array instead of numpy.asarray to avoid this issue.

Fixes #832 