### PR TITLE
Fix macos

### DIFF
--- a/amulet_map_editor/api/opengl/canvas/canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/canvas.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import logging
+import sys
 
 import wx
 from wx import glcanvas
@@ -48,7 +49,16 @@ class BaseCanvas(glcanvas.GLCanvas):
             style=wx.WANTS_CHARS,
         )
 
-        self._context = glcanvas.GLContext(self)
+        if sys.platform == "linux":
+            # setup the OpenGL context. This apparently fixes Amulet-Team/Amulet-Map-Editor#84
+            self._context = glcanvas.GLContext(self)
+        else:
+            # This is required for MacOS. Amulet-Team/Amulet-Map-Editor#597
+            context_attributes = wx.glcanvas.GLContextAttrs()
+            context_attributes.CoreProfile().Robust().ResetIsolation().EndList()
+            self._context = glcanvas.GLContext(
+                self, ctxAttrs=context_attributes
+            )  # setup the OpenGL context
         if not self._context.IsOK():
             raise Exception(f"Failed setting up context")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,8 @@ install_requires =
     wxPython==4.1.1
     numpy~=1.17
     pyopengl~=3.0
-    pyopengl-accelerate~=3.0
+    ; pyopengl-accelerate does not work for M1 Macs. Amulet-Team/Amulet-Map-Editor#597
+    pyopengl-accelerate~=3.0; sys_platform!="darwin" or (sys_platform=="darwin" and platform_machine!="arm")
     packaging
     amulet-core~=1.9
     amulet-nbt~=2.0


### PR DESCRIPTION
This fixes a shader compilation error on MacOS.
Disables opengl-accelerate on M1 macs.

Fixes #597 