### PR TITLE
Removed Python 3.9 limit

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-        - {os: windows-latest, python-version: 3.7, architecture: x64}
-        - {os: windows-latest, python-version: 3.7, architecture: x86}
+        - {os: windows-latest, python-version: '3.9', architecture: x64}
+        - {os: windows-latest, python-version: '3.9', architecture: x86}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Extract the contained folder to a location on your computer and run the executab
 
 **If you are running a compiled build you do NOT need to do this.**
 
-1) Install [Python 3.7-3.9](https://www.python.org/)
+1) Install [Python 3.9+](https://www.python.org/)
 2) We recommend setting up a [python virtual environment](https://docs.python.org/3/tutorial/venv.html) so you don't run into issues with dependency conflicts.
 3) run `python -m pip install amulet-map-editor` to install the library and all its dependencies.
 4) run `python -m amulet_map_editor` to run the program

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ platforms = any
 
 [options]
 include_package_data = True
-python_requires = >=3.6, <3.10
+python_requires = >=3.6
 install_requires =
     wxPython==4.1.1
     numpy~=1.17


### PR DESCRIPTION
A versions of wxpython has been released that has builds for newer versions of python. Updated build system to use 3.9 because the new version of wxpython does not have builds for 3.7

Resolves #914 