### PR TITLE
Remove win32 builds

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,10 +15,10 @@ jobs:
         shell: bash
 
     strategy:
+      fail-fast: false
       matrix:
         cfg:
         - {os: windows-latest, python-version: '3.9', architecture: x64}
-        - {os: windows-latest, python-version: '3.9', architecture: x86}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
There are not win32 builds for Pillow any more and the build was failing as a result.