### PR TITLE
Update import_tool.py

### DIFF
--- a/amulet_map_editor/programs/edit/plugins/tools/import_tool.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/import_tool.py
@@ -51,7 +51,7 @@ class ImportTool(wx.BoxSizer, DefaultBaseToolUI):
             "Open a Minecraft data file",
             wildcard="|".join(
                 [  # TODO: Automatically load these from the FormatWrapper classes.
-                    "All files (*.construction;*.mcstructure;*.schematic)|*.construction;*.mcstructure;*.schematic",
+                    "All files (*.construction;*.mcstructure;*.schematic .schem)|*.construction;*.mcstructure;*.schematic;*.schem",
                     "Construction file (*.construction)|*.construction",
                     "Bedrock mcstructure file (*.mcstructure)|*.mcstructure",
                     "Legacy Schematic file (*.schematic)|*.schematic",


### PR DESCRIPTION
Small fix to also include .schem files by default when importing a schematic
(this just anoyed me)