### PR TITLE
Refactored warning dialog

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -6,25 +6,16 @@ import traceback
 import logging
 
 from amulet.api.errors import LoaderNoneMatched
-from amulet_map_editor.api import config
 from amulet_map_editor.api.wx.ui.select_world import open_level_from_dialog
 from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor import __version__, lang
 from amulet_map_editor.api.framework.pages import WorldPageUI
 from .pages import AmuletMainMenu, BasePageUI
-from .warning_dialog import WarningDialog
 
 from amulet_map_editor.api import image
 from amulet_map_editor.api.wx.util.ui_preferences import preserve_ui_preferences
 
 log = logging.getLogger(__name__)
-
-# Uses a conditional so if this breaks a build, we can just delete the file and it will skip the check
-try:
-    from amulet_map_editor.api.framework import update_check
-except ImportError:
-    update_check = None
-    log.warning("Could not import update checker")
 
 NOTEBOOK_MENU_STYLE = (
     flatnotebook.FNB_NO_X_BUTTON
@@ -71,23 +62,6 @@ class AmuletUI(wx.Frame):
         self._level_notebook.init()
 
         self.Bind(wx.EVT_CLOSE, self._level_notebook.on_app_close)
-
-        meta_config = config.get("amulet_meta", {})
-        if not meta_config.get("do_not_show_warning_dialog", False):
-            warning_dialog = WarningDialog(self)
-            warning_dialog.ShowModal()
-            if warning_dialog.do_not_show_again:
-                meta_config["do_not_show_warning_dialog"] = True
-                config.put("amulet_meta", meta_config)
-
-        if update_check:
-            self.Bind(
-                update_check.EVT_UPDATE_CHECK,
-                lambda evt: update_check.UpdateDialog(
-                    self, __version__, evt.GetVersion()
-                ).ShowModal(),
-            )
-            update_check.check_for_update(self, __version__)
 
     def open_level(self, path: str):
         """Open a level. You should use the method in the app."""

--- a/amulet_map_editor/api/framework/app.py
+++ b/amulet_map_editor/api/framework/app.py
@@ -2,6 +2,20 @@ import wx
 from . import amulet_ui
 import sys
 import locale
+import logging
+
+from amulet_map_editor.api import config
+from amulet_map_editor import __version__
+from .warning_dialog import WarningDialog
+
+log = logging.getLogger(__name__)
+
+# Uses a conditional so if this breaks a build, we can just delete the file and it will skip the check
+try:
+    from amulet_map_editor.api.framework import update_check
+except ImportError:
+    update_check = None
+    log.warning("Could not import update checker")
 
 
 class AmuletApp(wx.App):
@@ -11,6 +25,25 @@ class AmuletApp(wx.App):
         self._amulet_ui = amulet_ui.AmuletUI(None)
         self.SetTopWindow(self._amulet_ui)
         self._amulet_ui.Show()
+
+        meta_config = config.get("amulet_meta", {})
+        if not meta_config.get("do_not_show_warning_dialog", False):
+            warning_dialog = WarningDialog(self._amulet_ui)
+            warning_dialog.Centre()
+            warning_dialog.ShowModal()
+            if warning_dialog.do_not_show_again:
+                meta_config["do_not_show_warning_dialog"] = True
+                config.put("amulet_meta", meta_config)
+
+        if update_check:
+            self.Bind(
+                update_check.EVT_UPDATE_CHECK,
+                lambda evt: update_check.UpdateDialog(
+                    self, __version__, evt.GetVersion()
+                ).ShowModal(),
+            )
+            update_check.check_for_update(self, __version__)
+
         return True
 
     def InitLocale(self):


### PR DESCRIPTION
The main window is first shown and then the warning dialog is shown over it. This may be the source of some of the window not displaying issues.

May fix #967 