### PR TITLE
Improved plugin error handling

### DIFF
--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -217,7 +217,7 @@ class EditCanvas(BaseEditCanvas):
     ) -> Any:
         try:
             out = self._run_operation(operation, title, msg, True)
-        except Exception as e:
+        except BaseException as e:
             if throw_exceptions:
                 raise e
         else:

--- a/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
+++ b/amulet_map_editor/programs/edit/api/operations/manager/operation_manager.py
@@ -100,13 +100,9 @@ class BaseOperationManager:
             try:
                 mod = importlib.import_module(module_name)
                 mod = importlib.reload(mod)
-            except ImportError:
+            except BaseException:
                 log.warning(
-                    f"Failed to import {module_name}.\n{traceback.format_exc()}"
-                )
-            except SyntaxError:
-                log.warning(
-                    f"There was a syntax error in {module_name}.\n{traceback.format_exc()}"
+                    f"There was an exception while loading operation {module_name}.\n{traceback.format_exc()}"
                 )
             else:
                 if (


### PR DESCRIPTION
Catch any exception raised when loading or running a plugin to better sandbox it. Catching BaseException will catch all exceptions and stop them propagating up the program.

Fixes #943 