### PR TITLE
Bump python version and updated build scripts

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -21,7 +21,7 @@ jobs:
         - {os: windows-latest, python-version: '3.9', architecture: x64}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.cfg.python-version }} ${{ matrix.cfg.architecture }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ['3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ['3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ platforms = any
 
 [options]
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     wxPython
     numpy~=1.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ platforms = any
 include_package_data = True
 python_requires = >=3.9
 install_requires =
+    Pillow>=10.0.1
     wxPython
     numpy~=1.17
     pyopengl~=3.0


### PR DESCRIPTION
Dropped support for Python 3.7 and 3.8.
3.7 is EOL and 3.9 implemented better typing hinting.
Updated github actions.
Updated readthedocs config.