### PR TITLE
Use a 'default' instead of a 'decorative' font family

### DIFF
--- a/amulet_map_editor/api/framework/pages/main_menu.py
+++ b/amulet_map_editor/api/framework/pages/main_menu.py
@@ -36,12 +36,12 @@ class AmuletMainMenu(wx.Panel, BasePageUI):
         name_sizer.Add(icon, flag=wx.CENTER)
 
         self._amulet_name = wx.StaticText(self)
-        self._amulet_name.SetFont(wx.Font(40, wx.DECORATIVE, wx.NORMAL, wx.NORMAL))
+        self._amulet_name.SetFont(wx.Font(40, wx.DEFAULT, wx.NORMAL, wx.NORMAL))
         name_sizer.Add(
             self._amulet_name, flag=wx.CENTER | wx.LEFT | wx.RIGHT, border=10
         )
         name_sizer.Add(icon2, flag=wx.CENTER)
-        button_font = wx.Font(20, wx.DECORATIVE, wx.NORMAL, wx.NORMAL)
+        button_font = wx.Font(20, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
         self._open_world_button = wx.Button(self, size=(400, 70))
         self._open_world_button.SetFont(button_font)
         self._open_world_button.Bind(

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -58,7 +58,7 @@ class EditExtension(wx.Panel, BaseProgram):
         self._temp_msg = wx.StaticText(
             self, label=lang.get("program_3d_edit.canvas.please_wait")
         )
-        self._temp_msg.SetFont(wx.Font(40, wx.DECORATIVE, wx.NORMAL, wx.NORMAL))
+        self._temp_msg.SetFont(wx.Font(40, wx.DEFAULT, wx.NORMAL, wx.NORMAL))
         self._sizer.Add(self._temp_msg, 0, flag=wx.ALIGN_CENTER_HORIZONTAL)
         self._temp_loading_bar = wx.Gauge(self, range=10000)
         self._sizer.Add(self._temp_loading_bar, 0, flag=wx.EXPAND)


### PR DESCRIPTION
On Unix systems, the wxWidgets / wxPython font family `wx.DECORATIVE` defaults to Impact [^1]. For a more suitable UI font, this is changed to `wx.DEFAULT`.

On modern macOS and Windows systems, this is expected to have minimal impact (no pun intended), as `wx.DECORATIVE` already seems to be equivalent to `wx.DEFAULT` on both platforms [^2][^3].

Even with its original intent, the 'decorative' font family is not a good match for the UI, as it corresponds to the `fantasy` font family in CSS, that mostly includes gimmicky fonts like Papyrus or Jokerman [^4].

| Before (Impact) |
|:--:|
| ![Before](https://github.com/user-attachments/assets/3e7f9b12-1ad9-4be7-b8bf-1285e141bde2) |

| After (Noto Sans) |
|:--:|
| ![After](https://github.com/user-attachments/assets/78f5d764-0165-4b1d-80de-a71f7bc48c77) |

Resolves #1172

[^1]: https://github.com/wxWidgets/wxWidgets/blob/18da5b8269706472f6c0fa09dcbae605a477da19/src/unix/fontutil.cpp#L274-L277
[^2]: https://github.com/wxWidgets/wxWidgets/blob/18da5b8269706472f6c0fa09dcbae605a477da19/src/osx/carbon/font.cpp#L218-L220
[^3]: https://github.com/wxWidgets/wxWidgets/issues/24178
[^4]: https://web.archive.org/web/20130126125901/http://www.codestyle.org/css/font-family/sampler-Fantasy.shtml