### PR TITLE
Improve key selection

### DIFF
--- a/amulet_map_editor/api/wx/util/key_config.py
+++ b/amulet_map_editor/api/wx/util/key_config.py
@@ -1,4 +1,5 @@
 import wx
+from amulet_map_editor.api import lang
 from amulet_map_editor.api.wx.ui.simple import (
     SimpleDialog,
     SimpleScrollablePanel,
@@ -306,7 +307,7 @@ class KeyCatcher(wx.Dialog):
     def __init__(self, parent: wx.Window, action: str):
         super().__init__(
             parent,
-            title=f"Press the key you want assigned to {action}",
+            title=lang.get("key_config.press_label").format(action=lang.get(f"action.{action.lower()}")),
             style=wx.DEFAULT_DIALOG_STYLE | wx.WANTS_CHARS,
         )
 
@@ -356,7 +357,7 @@ class KeyConfigDialog(SimpleDialog):
         fixed_keybinds: KeybindContainer,
         user_keybinds: KeybindContainer,
     ):
-        super().__init__(parent, "Key Select")
+        super().__init__(parent, lang.get("key_config.key_select"))
         self._key_config = KeyConfig(
             self, selected_group, entries, fixed_keybinds, user_keybinds
         )
@@ -413,7 +414,7 @@ class KeyConfig(wx.BoxSizer):
         self._key_buttons: Dict[str, wx.Button] = {}
         for action in entries:
             grid_sizer.Add(
-                wx.StaticText(self._options, label=action.title()), 0, wx.ALIGN_CENTER
+                wx.StaticText(self._options, label=lang.get(f"action.{action.lower()}")), 0, wx.ALIGN_CENTER
             )
             self._key_buttons[action] = button = wx.Button(self._options)
             button.Bind(wx.EVT_BUTTON, lambda evt, a=action: self._modify_button(a))
@@ -456,7 +457,7 @@ class KeyConfig(wx.BoxSizer):
     def _request_group_name(self) -> Optional[str]:
         group_name = ""
         while group_name == "":
-            msg = wx.TextEntryDialog(self._options, "Enter a new group name.")
+            msg = wx.TextEntryDialog(self._options, lang.get("key_config.enter_group_name"))
             if msg.ShowModal() == wx.ID_OK:
                 group_name = msg.GetValue()
                 if (
@@ -495,7 +496,7 @@ class KeyConfig(wx.BoxSizer):
         if self._choice.GetCurrentString() in self._fixed_keybinds:
             msg = wx.MessageDialog(
                 self._options,
-                "The active key group is not editable. Would you like to create a new group to edit?",
+                lang.get("key_config.active_not_editable"),
                 style=wx.YES_NO,
             )
             if msg.ShowModal() == wx.ID_YES:

--- a/amulet_map_editor/api/wx/util/key_config.py
+++ b/amulet_map_editor/api/wx/util/key_config.py
@@ -307,7 +307,9 @@ class KeyCatcher(wx.Dialog):
     def __init__(self, parent: wx.Window, action: str):
         super().__init__(
             parent,
-            title=lang.get("key_config.press_label").format(action=lang.get(f"action.{action.lower()}")),
+            title=lang.get("key_config.press_label").format(
+                action=lang.get(f"action.{action.lower()}")
+            ),
             style=wx.DEFAULT_DIALOG_STYLE | wx.WANTS_CHARS,
         )
 
@@ -414,7 +416,11 @@ class KeyConfig(wx.BoxSizer):
         self._key_buttons: Dict[str, wx.Button] = {}
         for action in entries:
             grid_sizer.Add(
-                wx.StaticText(self._options, label=lang.get(f"action.{action.lower()}")), 0, wx.ALIGN_CENTER
+                wx.StaticText(
+                    self._options, label=lang.get(f"action.{action.lower()}")
+                ),
+                0,
+                wx.ALIGN_CENTER,
             )
             self._key_buttons[action] = button = wx.Button(self._options)
             button.Bind(wx.EVT_BUTTON, lambda evt, a=action: self._modify_button(a))
@@ -457,7 +463,9 @@ class KeyConfig(wx.BoxSizer):
     def _request_group_name(self) -> Optional[str]:
         group_name = ""
         while group_name == "":
-            msg = wx.TextEntryDialog(self._options, lang.get("key_config.enter_group_name"))
+            msg = wx.TextEntryDialog(
+                self._options, lang.get("key_config.enter_group_name")
+            )
             if msg.ShowModal() == wx.ID_OK:
                 group_name = msg.GetValue()
                 if (

--- a/amulet_map_editor/lang/en.lang
+++ b/amulet_map_editor/lang/en.lang
@@ -130,6 +130,12 @@ select_world.recent_worlds=Recently Opened Worlds
 select_world.no_loader_found=Could not find a loader for this world.
 select_world.loading_world_failed=Error loading world.
 
+# Key configuration dialog
+key_config.key_select=Key Select
+key_config.press_label=Press the key you want assigned to {action}
+key_config.enter_group_name=Enter a new group name.
+key_config.active_not_editable=The active key group is not editable. Would you like to create a new group to edit?
+
 # About
 ## The default program when a world is opened
 program_about.tab_name=About
@@ -165,6 +171,27 @@ program_3d_edit.canvas.loading_resource_packs=Loading resource packs
 program_3d_edit.canvas.retry_download=Failed to download the resource pack. Do you want to retry?
 program_3d_edit.canvas.creating_texture_atlas=Creating texture atlas
 program_3d_edit.canvas.setting_up_renderer=Setting up renderer
+
+## Controls
+action.act_move_up=Move Up
+action.act_move_down=Move Down
+action.act_move_forwards=Move Forwards
+action.act_move_backwards=Move Backwards
+action.act_move_left=Move Left
+action.act_move_right=Move Right
+action.act_box_click=Select Box
+action.act_box_click_add=Add Box
+action.act_change_mouse_mode=Rotate Camera
+action.act_incr_speed=Increase Speed (3D)
+action.act_decr_speed=Decrease Speed (3D)
+action.act_zoom_in=Zoom In (2D)
+action.act_zoom_out=Zoom Out (2D)
+action.act_incr_select_distance=Increase Selection Distance
+action.act_decr_select_distance=Decrease Selection Distance
+action.act_deselect_all_boxes=Deselect All Boxes
+action.act_deselect_box=Deselect Active Box
+action.act_inspect_block=Inspect Block
+action.act_change_projection=Toggle Projection
 
 ## Menu bar
 program_3d_edit.menu_bar.file.save=Save

--- a/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
@@ -28,7 +28,7 @@ from ..key_config import (
     ACT_INCR_SELECT_DISTANCE,
     ACT_DECR_SELECT_DISTANCE,
     ACT_DESELECT_ALL_BOXES,
-    ACT_DELESECT_BOX,
+    ACT_DESELECT_BOX,
 )
 
 if TYPE_CHECKING:
@@ -231,7 +231,7 @@ class BlockSelectionBehaviour(PointerBehaviour):
                 self._post_change_event()
             else:
                 self._escape()
-        elif evt.action_id == ACT_DELESECT_BOX:
+        elif evt.action_id == ACT_DESELECT_BOX:
             if ACT_DESELECT_ALL_BOXES not in self.canvas.buttons.pressed_actions:
                 selection_group = self.selection_group
                 if selection_group:

--- a/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
@@ -25,6 +25,8 @@ from ..key_config import (
     ACT_CHANGE_MOUSE_MODE,
     ACT_INCR_SPEED,
     ACT_DECR_SPEED,
+    ACT_ZOOM_IN,
+    ACT_ZOOM_OUT,
     ACT_CHANGE_PROJECTION,
 )
 
@@ -86,12 +88,14 @@ class CameraBehaviour(BaseBehaviour):
         elif evt.action_id == ACT_INCR_SPEED:
             if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
                 self.canvas.camera.move_speed *= 1.1
-            elif self.canvas.camera.projection_mode == Projection.TOP_DOWN:
-                self.canvas.camera.fov = max(0.5, self.canvas.camera.fov / 1.1)
         elif evt.action_id == ACT_DECR_SPEED:
             if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
                 self.canvas.camera.move_speed /= 1.1
-            elif self.canvas.camera.projection_mode == Projection.TOP_DOWN:
+        elif evt.action_id == ACT_ZOOM_IN:
+            if self.canvas.camera.projection_mode == Projection.TOP_DOWN:
+                self.canvas.camera.fov = max(0.5, self.canvas.camera.fov / 1.1)
+        elif evt.action_id == ACT_ZOOM_OUT:
+            if self.canvas.camera.projection_mode == Projection.TOP_DOWN:
                 self.canvas.camera.fov = min(1000.0, self.canvas.camera.fov * 1.1)
 
     def _on_input_held(self, evt: InputHeldEvent):

--- a/amulet_map_editor/programs/edit/api/behaviour/chunk_selection_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/chunk_selection_behaviour.py
@@ -19,7 +19,7 @@ from amulet_map_editor.api.opengl.camera import Projection
 from ..key_config import (
     ACT_BOX_CLICK,
     ACT_DESELECT_ALL_BOXES,
-    ACT_DELESECT_BOX,
+    ACT_DESELECT_BOX,
 )
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class ChunkSelectionBehaviour(PointerBehaviour):
         elif evt.action_id == ACT_DESELECT_ALL_BOXES:
             self._selection.selection_group = SelectionGroup()
             self._create_undo()
-        elif evt.action_id == ACT_DELESECT_BOX:
+        elif evt.action_id == ACT_DESELECT_BOX:
             if ACT_DESELECT_ALL_BOXES not in self.canvas.buttons.pressed_actions:
                 self._selection.selection_group = SelectionGroup()
                 self._create_undo()

--- a/amulet_map_editor/programs/edit/api/key_config.py
+++ b/amulet_map_editor/programs/edit/api/key_config.py
@@ -26,10 +26,12 @@ ACT_BOX_CLICK_ADD = "ACT_BOX_CLICK_ADD"
 ACT_CHANGE_MOUSE_MODE = "ACT_CHANGE_MOUSE_MODE"
 ACT_INCR_SPEED = "ACT_INCR_SPEED"
 ACT_DECR_SPEED = "ACT_DECR_SPEED"
+ACT_ZOOM_IN = "ACT_ZOOM_IN"
+ACT_ZOOM_OUT = "ACT_ZOOM_OUT"
 ACT_INCR_SELECT_DISTANCE = "ACT_INCR_SELECT_DISTANCE"
 ACT_DECR_SELECT_DISTANCE = "ACT_DECR_SELECT_DISTANCE"
 ACT_DESELECT_ALL_BOXES = "ACT_DESELECT_ALL_BOXES"
-ACT_DELESECT_BOX = "ACT_DELESECT_BOX"
+ACT_DESELECT_BOX = "ACT_DESELECT_BOX"
 ACT_INSPECT_BLOCK = "ACT_INSPECT_BLOCK"
 ACT_CHANGE_PROJECTION = "ACT_CHANGE_PROJECTION"
 
@@ -45,10 +47,12 @@ KeybindKeys: List[KeyActionType] = [
     ACT_CHANGE_MOUSE_MODE,
     ACT_INCR_SPEED,
     ACT_DECR_SPEED,
+    ACT_ZOOM_IN,
+    ACT_ZOOM_OUT,
     ACT_INCR_SELECT_DISTANCE,
     ACT_DECR_SELECT_DISTANCE,
     ACT_DESELECT_ALL_BOXES,
-    ACT_DELESECT_BOX,
+    ACT_DESELECT_BOX,
     ACT_INSPECT_BLOCK,
     ACT_CHANGE_PROJECTION,
 ]
@@ -66,10 +70,12 @@ PresetKeybinds: KeybindContainer = {
         ACT_CHANGE_MOUSE_MODE: ((), MouseRight),
         ACT_INCR_SPEED: ((), MouseWheelScrollUp),
         ACT_DECR_SPEED: ((), MouseWheelScrollDown),
+        ACT_ZOOM_IN: ((), MouseWheelScrollUp),
+        ACT_ZOOM_OUT: ((), MouseWheelScrollDown),
         ACT_INCR_SELECT_DISTANCE: ((), "R"),
         ACT_DECR_SELECT_DISTANCE: ((), "F"),
         ACT_DESELECT_ALL_BOXES: ((Control, Shift), "D"),
-        ACT_DELESECT_BOX: ((Control,), "D"),
+        ACT_DESELECT_BOX: ((Control,), "D"),
         ACT_INSPECT_BLOCK: ((), Alt),
         ACT_CHANGE_PROJECTION: ((), Tab),
     },
@@ -85,10 +91,12 @@ PresetKeybinds: KeybindContainer = {
         ACT_CHANGE_MOUSE_MODE: ((), MouseRight),
         ACT_INCR_SPEED: ((), "."),
         ACT_DECR_SPEED: ((), ","),
+        ACT_ZOOM_IN: ((), "."),
+        ACT_ZOOM_OUT: ((), ","),
         ACT_INCR_SELECT_DISTANCE: ((), "R"),
         ACT_DECR_SELECT_DISTANCE: ((), "F"),
         ACT_DESELECT_ALL_BOXES: ((Control, Shift), "D"),
-        ACT_DELESECT_BOX: ((Control,), "D"),
+        ACT_DESELECT_BOX: ((Control,), "D"),
         ACT_INSPECT_BLOCK: ((), Alt),
         ACT_CHANGE_PROJECTION: ((), Tab),
     },
@@ -104,10 +112,12 @@ PresetKeybinds: KeybindContainer = {
         ACT_CHANGE_MOUSE_MODE: ((), MouseRight),
         ACT_INCR_SPEED: ((), MouseWheelScrollUp),
         ACT_DECR_SPEED: ((), MouseWheelScrollDown),
+        ACT_ZOOM_IN: ((), MouseWheelScrollUp),
+        ACT_ZOOM_OUT: ((), MouseWheelScrollDown),
         ACT_INCR_SELECT_DISTANCE: ((), "Y"),
         ACT_DECR_SELECT_DISTANCE: ((), "H"),
         ACT_DESELECT_ALL_BOXES: ((Control, Shift), "D"),
-        ACT_DELESECT_BOX: ((Control,), "D"),
+        ACT_DESELECT_BOX: ((Control,), "D"),
         ACT_INSPECT_BLOCK: ((), Alt),
         ACT_CHANGE_PROJECTION: ((), Tab),
     },
@@ -123,10 +133,12 @@ PresetKeybinds: KeybindContainer = {
         ACT_CHANGE_MOUSE_MODE: ((), MouseRight),
         ACT_INCR_SPEED: ((), "."),
         ACT_DECR_SPEED: ((), ","),
+        ACT_ZOOM_IN: ((), "."),
+        ACT_ZOOM_OUT: ((), ","),
         ACT_INCR_SELECT_DISTANCE: ((), "Y"),
         ACT_DECR_SELECT_DISTANCE: ((), "H"),
         ACT_DESELECT_ALL_BOXES: ((Control, Shift), "D"),
-        ACT_DELESECT_BOX: ((Control,), "D"),
+        ACT_DESELECT_BOX: ((Control,), "D"),
         ACT_INSPECT_BLOCK: ((), Alt),
         ACT_CHANGE_PROJECTION: ((), Tab),
     },

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ platforms = any
 
 [options]
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     Pillow>=10.0.1
     wxPython


### PR DESCRIPTION
Add localised strings for actions.
Split controls for speed and zoom.
Fix typo in ACT_DESELECT_BOX

Fixes #1243 