### PR TITLE
Limit meshing to 1 thread

### DIFF
--- a/amulet_map_editor/api/opengl/mesh/level/chunk/chunk_builder_cy.pyx
+++ b/amulet_map_editor/api/opengl/mesh/level/chunk/chunk_builder_cy.pyx
@@ -366,8 +366,7 @@ cdef tuple _create_lod0_chunk(
             chunk_offset[2]
         )
 
-    for i in prange(sub_chunk_count, nogil=True):
-    # for i in range(sub_chunk_count):
+    for i in prange(sub_chunk_count, nogil=True, num_threads=1):
         sub_chunk_verts[i] = create_lod0_sub_chunk(
             block_array_list[i],
             block_model_manager,


### PR DESCRIPTION
On my 16 core CPU Amulet was maxing out the whole processor but was not getting much of a speed boost. I think most of the CPU time is spent spawning and destroying threads because the work being done is so small. After profiling it seems that adding more threads makes it a little faster but not much. Using all cores makes it run slower than just one. I think most of the benefit is from running the meshing code independently of the GIL. I have decided to limit meshing to 1 thread.

Tests (times in seconds + frames out of 60)
range with gil = 41+19
prange(cpu) = 33+24
prange(4) = 31+05
prange(2) = 31+14
prange(1) = 31+36