### PR TITLE
Refactor drawing

### DIFF
--- a/amulet_map_editor/api/opengl/events.py
+++ b/amulet_map_editor/api/opengl/events.py
@@ -8,4 +8,3 @@ from .camera import (
 )
 
 PreDrawEvent, EVT_PRE_DRAW = newevent.NewEvent()
-DrawEvent, EVT_DRAW = newevent.NewEvent()

--- a/amulet_map_editor/api/opengl/events.py
+++ b/amulet_map_editor/api/opengl/events.py
@@ -9,4 +9,3 @@ from .camera import (
 
 PreDrawEvent, EVT_PRE_DRAW = newevent.NewEvent()
 DrawEvent, EVT_DRAW = newevent.NewEvent()
-PostDrawEvent, EVT_POST_DRAW = newevent.NewEvent()

--- a/amulet_map_editor/programs/edit/api/events.py
+++ b/amulet_map_editor/programs/edit/api/events.py
@@ -13,8 +13,6 @@ from amulet_map_editor.api.opengl.camera import (
 from amulet_map_editor.api.opengl.events import (
     PreDrawEvent,
     EVT_PRE_DRAW,
-    DrawEvent,
-    EVT_DRAW,
 )
 
 from amulet_map_editor.api.wx.util.button_input import (

--- a/amulet_map_editor/programs/edit/api/events.py
+++ b/amulet_map_editor/programs/edit/api/events.py
@@ -15,8 +15,6 @@ from amulet_map_editor.api.opengl.events import (
     EVT_PRE_DRAW,
     DrawEvent,
     EVT_DRAW,
-    PostDrawEvent,
-    EVT_POST_DRAW,
 )
 
 from amulet_map_editor.api.wx.util.button_input import (

--- a/amulet_map_editor/programs/edit/api/operations/base/default_operation_ui.py
+++ b/amulet_map_editor/programs/edit/api/operations/base/default_operation_ui.py
@@ -9,7 +9,6 @@ from OpenGL.GL import (
 from .operation_ui import OperationUI
 from amulet_map_editor.programs.edit.api.behaviour import StaticSelectionBehaviour
 from amulet_map_editor.api.opengl.camera import Projection
-from amulet_map_editor.programs.edit.api.events import EVT_DRAW
 from amulet_map_editor.programs.edit.api.behaviour import (
     CameraBehaviour,
     PointerBehaviour,
@@ -52,7 +51,7 @@ class DefaultOperationUI(OperationUI):
 
     def bind_events(self):
         self._selection.bind_events()
-        self.canvas.Bind(EVT_DRAW, self._on_draw)
+        self.canvas.Bind(wx.EVT_PAINT, self._on_draw)
         self._camera_behaviour.bind_events()
         self._pointer.bind_events()
         self.canvas.Bind(EVT_INPUT_PRESS, self._on_input_press)

--- a/amulet_map_editor/programs/edit/api/operations/base/default_operation_ui.py
+++ b/amulet_map_editor/programs/edit/api/operations/base/default_operation_ui.py
@@ -59,17 +59,21 @@ class DefaultOperationUI(OperationUI):
 
     def _on_draw(self, evt):
         try:
-            self.canvas.renderer.start_draw()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self.canvas.renderer.draw_sky_box()
-                glClear(GL_DEPTH_BUFFER_BIT)
-            self.canvas.renderer.draw_level()
-            self._selection.draw()
-            if self._show_pointer:
-                self._pointer.draw()
-            self.canvas.renderer.end_draw()
+            self.canvas.SetCurrent(self.canvas.context)
+            self._draw()
         except Exception as e:
             log.exception(f"Failed painting: {e}")
+
+    def _draw(self):
+        self.canvas.renderer.start_draw()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self.canvas.renderer.draw_sky_box()
+            glClear(GL_DEPTH_BUFFER_BIT)
+        self.canvas.renderer.draw_level()
+        self._selection.draw()
+        if self._show_pointer:
+            self._pointer.draw()
+        self.canvas.renderer.end_draw()
 
     def _on_input_press(self, evt: InputPressEvent):
         if evt.action_id == ACT_BOX_CLICK:

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -21,7 +21,6 @@ from .events import (
     CameraMovedEvent,
     EVT_CAMERA_MOVED,
     PreDrawEvent,
-    DrawEvent,
 )
 
 if TYPE_CHECKING:
@@ -201,7 +200,7 @@ class Renderer(EditCanvasContainer):
 
     def _do_draw(self, evt):
         wx.PostEvent(self.canvas, PreDrawEvent())
-        wx.PostEvent(self.canvas, DrawEvent())
+        self.canvas.Refresh(False)
 
     def default_draw(self):
         """The default draw logic."""

--- a/amulet_map_editor/programs/edit/api/renderer.py
+++ b/amulet_map_editor/programs/edit/api/renderer.py
@@ -22,7 +22,6 @@ from .events import (
     EVT_CAMERA_MOVED,
     PreDrawEvent,
     DrawEvent,
-    PostDrawEvent,
 )
 
 if TYPE_CHECKING:
@@ -203,7 +202,6 @@ class Renderer(EditCanvasContainer):
     def _do_draw(self, evt):
         wx.PostEvent(self.canvas, PreDrawEvent())
         wx.PostEvent(self.canvas, DrawEvent())
-        wx.PostEvent(self.canvas, PostDrawEvent())
 
     def default_draw(self):
         """The default draw logic."""

--- a/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
@@ -14,7 +14,6 @@ from amulet.api.errors import LoaderNoneMatched
 from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
 from amulet_map_editor.api.opengl.camera import Projection
 from .base_tool_ui import BaseToolUI
-from amulet_map_editor.programs.edit.api.events import EVT_DRAW
 from amulet_map_editor.programs.edit.api.behaviour import CameraBehaviour
 
 if TYPE_CHECKING:
@@ -43,7 +42,7 @@ class DefaultBaseToolUI(BaseToolUI):
         """Bind all required events to the canvas.
         All events on the canvas will be automatically removed after the tool is disabled.
         """
-        self.canvas.Bind(EVT_DRAW, self._on_draw)
+        self.canvas.Bind(wx.EVT_PAINT, self._on_draw)
         self.canvas.SetDropTarget(None)  # fixes #239
         self.canvas.DragAcceptFiles(True)
         self.canvas.Bind(wx.EVT_DROP_FILES, self._on_drop_files)

--- a/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/default_base_tool_ui.py
@@ -52,14 +52,18 @@ class DefaultBaseToolUI(BaseToolUI):
     def _on_draw(self, evt):
         """The render loop for this tool."""
         try:
-            self.canvas.renderer.start_draw()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self.canvas.renderer.draw_sky_box()
-                glClear(GL_DEPTH_BUFFER_BIT)
-            self.canvas.renderer.draw_level()
-            self.canvas.renderer.end_draw()
+            self.canvas.SetCurrent(self.canvas.context)
+            self._draw()
         except Exception as e:
             log.exception(f"Failed painting: {e}")
+
+    def _draw(self):
+        self.canvas.renderer.start_draw()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self.canvas.renderer.draw_sky_box()
+            glClear(GL_DEPTH_BUFFER_BIT)
+        self.canvas.renderer.draw_level()
+        self.canvas.renderer.end_draw()
 
     def _on_drop_files(self, evt: wx.DropFilesEvent):
         """Logic to run when a file is dropped into the canvas."""

--- a/amulet_map_editor/programs/edit/plugins/tools/chunk.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/chunk.py
@@ -254,25 +254,22 @@ class ChunkTool(wx.BoxSizer, DefaultBaseToolUI):
                 )
             )
 
-    def _on_draw(self, evt):
-        try:
-            self.canvas.renderer.start_draw()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self.canvas.renderer.draw_sky_box()
-                glClear(GL_DEPTH_BUFFER_BIT)
-            self.canvas.renderer.draw_level()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self._selection.draw()
-            else:
-                depth_state = glGetBoolean(GL_DEPTH_TEST)
-                if depth_state:
-                    glDisable(GL_DEPTH_TEST)
-                clip = self.canvas.camera.orthographic_clipping
-                self.canvas.camera.orthographic_clipping = -(10**5), 10**5
-                self._selection.draw()
-                self.canvas.camera.orthographic_clipping = clip
-                if depth_state:
-                    glEnable(GL_DEPTH_TEST)
-            self.canvas.renderer.end_draw()
-        except Exception as e:
-            log.exception(f"Failed painting: {e}")
+    def _draw(self):
+        self.canvas.renderer.start_draw()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self.canvas.renderer.draw_sky_box()
+            glClear(GL_DEPTH_BUFFER_BIT)
+        self.canvas.renderer.draw_level()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self._selection.draw()
+        else:
+            depth_state = glGetBoolean(GL_DEPTH_TEST)
+            if depth_state:
+                glDisable(GL_DEPTH_TEST)
+            clip = self.canvas.camera.orthographic_clipping
+            self.canvas.camera.orthographic_clipping = -(10**5), 10**5
+            self._selection.draw()
+            self.canvas.camera.orthographic_clipping = clip
+            if depth_state:
+                glEnable(GL_DEPTH_TEST)
+        self.canvas.renderer.end_draw()

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -703,15 +703,12 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
     def _paste_confirm(self, evt):
         self.canvas.run_operation(self._paste_operation)
 
-    def _on_draw(self, evt):
-        try:
-            self.canvas.renderer.start_draw()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self.canvas.renderer.draw_sky_box()
-                glClear(GL_DEPTH_BUFFER_BIT)
-            self.canvas.renderer.draw_level()
-            self.canvas.renderer.draw_fake_levels()
-            self._selection.draw()
-            self.canvas.renderer.end_draw()
-        except Exception as e:
-            log.exception(f"Failed painting: {e}")
+    def _draw(self):
+        self.canvas.renderer.start_draw()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self.canvas.renderer.draw_sky_box()
+            glClear(GL_DEPTH_BUFFER_BIT)
+        self.canvas.renderer.draw_level()
+        self.canvas.renderer.draw_fake_levels()
+        self._selection.draw()
+        self.canvas.renderer.end_draw()

--- a/amulet_map_editor/programs/edit/plugins/tools/select.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/select.py
@@ -329,19 +329,15 @@ class SelectTool(wx.BoxSizer, DefaultBaseToolUI):
         for scroll in (self._x1, self._y1, self._z1, self._x2, self._y2, self._z2):
             scroll.Enable(state)
 
-    def _on_draw(self, evt):
+    def _draw(self):
         global paint_log_count
-        try:
-            self.canvas.renderer.start_draw()
-            if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
-                self.canvas.renderer.draw_sky_box()
-                glClear(GL_DEPTH_BUFFER_BIT)
-            self.canvas.renderer.draw_level()
-            self._selection.draw()
-            self.canvas.renderer.end_draw()
-        except Exception as e:
-            log.exception(f"Failed painting: {e}")
-        else:
-            if paint_log_count < 10:
-                paint_log_count += 1
-                log.debug(f"Painted frame. {paint_log_count}/10")
+        self.canvas.renderer.start_draw()
+        if self.canvas.camera.projection_mode == Projection.PERSPECTIVE:
+            self.canvas.renderer.draw_sky_box()
+            glClear(GL_DEPTH_BUFFER_BIT)
+        self.canvas.renderer.draw_level()
+        self._selection.draw()
+        self.canvas.renderer.end_draw()
+        if paint_log_count < 10:
+            paint_log_count += 1
+            log.debug(f"Painted frame. {paint_log_count}/10")


### PR DESCRIPTION
Only draw in `EVT_PAINT` handler.
Ensure the context is current when drawing.
This introduces some GUI flickering that I will fix in the next pull request.