### PR TITLE
Fix editor layout if resized while loading

### DIFF
--- a/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
+++ b/amulet_map_editor/programs/edit/api/canvas/edit_canvas.py
@@ -180,6 +180,7 @@ class EditCanvas(BaseEditCanvas):
     def enable(self):
         super().enable()
         self._tool_sizer.enable()
+        self.PostSizeEvent()
 
     def disable(self):
         super().disable()

--- a/amulet_map_editor/programs/edit/edit.py
+++ b/amulet_map_editor/programs/edit/edit.py
@@ -134,11 +134,9 @@ class EditExtension(wx.Panel, BaseProgram):
             self._sizer.Clear(True)
             self._sizer.Add(self._canvas, 1, wx.EXPAND)
             self._canvas.Show()
-            self._canvas._set_size()
             self.Layout()
-            wx.CallAfter(
-                self._canvas.enable
-            )  # This must be called after the show handler is run
+            # This must be called after the show handler is run
+            wx.CallAfter(self._canvas.enable)
             self._setup_thread = None
         except Exception as e:
             wx.CallAfter(self._display_error, str(e), traceback.format_exc())


### PR DESCRIPTION
If the window is resized while the editor is loading the GUI elements and renderer are in the wrong place. This fixes that