### PR TITLE
Make Ctrl+V in the paste tool confirm the paste

### DIFF
--- a/amulet_map_editor/programs/edit/api/ui/tool_manager.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool_manager.py
@@ -110,6 +110,9 @@ class ToolManagerSizer(wx.BoxSizer, EditCanvasContainer):
     def _enable_tool(self, tool: str, state=None):
         if tool in self._tools:
             if self._active_tool is not None:
+                if tool == "Paste" and isinstance(self._active_tool, PasteTool):
+                    self._active_tool.confirm_paste()
+                    return
                 self._active_tool.disable()
                 if isinstance(self._active_tool, wx.Window):
                     self._active_tool.Hide()

--- a/amulet_map_editor/programs/edit/plugins/tools/paste.py
+++ b/amulet_map_editor/programs/edit/plugins/tools/paste.py
@@ -708,6 +708,9 @@ class PasteTool(wx.BoxSizer, DefaultBaseToolUI):
             )
 
     def _paste_confirm(self, evt):
+        self.confirm_paste()
+
+    def confirm_paste(self) -> None:
         self.canvas.run_operation(self._paste_operation)
 
     def _on_resize(self, evt):


### PR DESCRIPTION
Before if you clicked Ctrl+V in the paste tool it would re-open the paste tool and reset your placement.
This make it so that in the paste tool Ctrl+V confirms the placement.

Fixes #1281 