### PR TITLE
Use window manager from OS for control dialog

### DIFF
--- a/amulet_map_editor/api/wx/ui/simple.py
+++ b/amulet_map_editor/api/wx/ui/simple.py
@@ -159,9 +159,15 @@ class SimpleChoiceAny(wx.Choice):
 class SimpleDialog(wx.Dialog):
     """A dialog with ok and cancel buttons set up."""
 
-    def __init__(self, parent: wx.Window, title, sizer_dir=wx.VERTICAL):
+    def __init__(
+        self,
+        parent: wx.Window,
+        title,
+        sizer_dir=wx.VERTICAL,
+        style=wx.CAPTION | wx.RESIZE_BORDER,
+    ):
         wx.Dialog.__init__(
-            self, parent, title=title, style=wx.CAPTION | wx.RESIZE_BORDER
+            self, parent, title=title, style=style
         )
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(sizer)

--- a/amulet_map_editor/api/wx/util/key_config.py
+++ b/amulet_map_editor/api/wx/util/key_config.py
@@ -358,17 +358,13 @@ class KeyConfigDialog(SimpleDialog):
         entries: Sequence[KeyActionType],
         fixed_keybinds: KeybindContainer,
         user_keybinds: KeybindContainer,
+        style: int = wx.CAPTION
+        | wx.CLOSE_BOX
+        | wx.MAXIMIZE_BOX
+        | wx.SYSTEM_MENU
+        | wx.RESIZE_BORDER,
     ):
-        super().__init__(
-            parent,
-            lang.get("key_config.key_select"),
-            style=wx.CAPTION
-            | wx.CLOSE_BOX
-            | wx.MAXIMIZE_BOX
-            | wx.MINIMIZE_BOX
-            | wx.SYSTEM_MENU
-            | wx.RESIZE_BORDER,
-        )
+        super().__init__(parent, lang.get("key_config.key_select"), style=style)
 
         self._key_config = KeyConfig(
             self, selected_group, entries, fixed_keybinds, user_keybinds

--- a/amulet_map_editor/api/wx/util/key_config.py
+++ b/amulet_map_editor/api/wx/util/key_config.py
@@ -359,7 +359,28 @@ class KeyConfigDialog(SimpleDialog):
         fixed_keybinds: KeybindContainer,
         user_keybinds: KeybindContainer,
     ):
-        super().__init__(parent, lang.get("key_config.key_select"))
+        # Initialize SimpleDialog but override the style to include window management
+        wx.Dialog.__init__(
+            self,
+            parent,
+            title=lang.get("key_config.key_select"),
+            style=wx.CAPTION
+            | wx.CLOSE_BOX
+            | wx.MAXIMIZE_BOX
+            | wx.MINIMIZE_BOX
+            | wx.SYSTEM_MENU
+            | wx.RESIZE_BORDER,
+        )
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(sizer)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.sizer, 1, wx.EXPAND)
+        self.bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        sizer.Add(self.bottom_sizer, 0, wx.EXPAND)
+        self.bottom_sizer.AddStretchSpacer()
+        button_sizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
+        self.bottom_sizer.Add(button_sizer, flag=wx.ALL, border=5)
+        
         self._key_config = KeyConfig(
             self, selected_group, entries, fixed_keybinds, user_keybinds
         )

--- a/amulet_map_editor/api/wx/util/key_config.py
+++ b/amulet_map_editor/api/wx/util/key_config.py
@@ -359,11 +359,9 @@ class KeyConfigDialog(SimpleDialog):
         fixed_keybinds: KeybindContainer,
         user_keybinds: KeybindContainer,
     ):
-        # Initialize SimpleDialog but override the style to include window management
-        wx.Dialog.__init__(
-            self,
+        super().__init__(
             parent,
-            title=lang.get("key_config.key_select"),
+            lang.get("key_config.key_select"),
             style=wx.CAPTION
             | wx.CLOSE_BOX
             | wx.MAXIMIZE_BOX
@@ -371,16 +369,7 @@ class KeyConfigDialog(SimpleDialog):
             | wx.SYSTEM_MENU
             | wx.RESIZE_BORDER,
         )
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        self.SetSizer(sizer)
-        self.sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(self.sizer, 1, wx.EXPAND)
-        self.bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(self.bottom_sizer, 0, wx.EXPAND)
-        self.bottom_sizer.AddStretchSpacer()
-        button_sizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
-        self.bottom_sizer.Add(button_sizer, flag=wx.ALL, border=5)
-        
+
         self._key_config = KeyConfig(
             self, selected_group, entries, fixed_keybinds, user_keybinds
         )


### PR DESCRIPTION
The controls dialog does not have standard OS buttons for the window.   Maximizing and Closing are manual operations and not fast like other applications.  (yes closing is available with the buttons on the bottom but not fast).  Escape doesn't do anything like a regular dialog so let's treat this as a real window.

This patch allows the OS to control the window and add standard buttons.  Only tested on Windows so far.