### PR TITLE
Rename macOS app names

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -75,20 +75,20 @@ jobs:
       run: |
         brew install create-dmg
         mkdir -p "installer/dist/dmg"
-        ditto "installer/dist/amulet.app" "installer/dist/dmg/amulet.app"
-        codesign --verify --deep --strict installer/dist/dmg/amulet.app
+        ditto "installer/dist/Amulet ${{ github.event.release.tag_name }}.app" "installer/dist/dmg/Amulet ${{ github.event.release.tag_name }}.app"
+        codesign --verify --deep --strict installer/dist/dmg/Amulet ${{ github.event.release.tag_name }}.app
         create-dmg \
-          --volname "Amulet-${{ github.event.release.tag_name }}" \
+          --volname "Amulet ${{ github.event.release.tag_name }} installer" \
           --volicon "installer/logo.icns" \
           --window-pos 200 120 \
           --window-size 600 300 \
           --icon-size 100 \
-          --icon "amulet.app" 175 120 \
-          --hide-extension "amulet.app" \
+          --icon "Amulet ${{ github.event.release.tag_name }}.app" 175 120 \
+          --hide-extension "Amulet ${{ github.event.release.tag_name }}.app" \
           --app-drop-link 425 120 \
           "installer/dist/Amulet-${{ github.event.release.tag_name }}-macOS-${{ matrix.cfg.architecture }}.dmg" \
           "installer/dist/dmg"
-        rm -rf installer/dist/amulet.app
+        rm -rf installer/dist/Amulet ${{ github.event.release.tag_name }}.app
         rm -rf installer/dist/amulet
         rm -rf installer/dist/dmg
 

--- a/installer/Amulet.spec
+++ b/installer/Amulet.spec
@@ -82,7 +82,7 @@ coll = COLLECT(
 
 app = BUNDLE(
     coll,
-    name="amulet.app",
+    name=f"Amulet {amulet_map_editor.__version__}.app",
     icon="logo.ico",
     bundle_identifier="com.amuletmc.amulet_map_editor",
 )


### PR DESCRIPTION
Add version number to app name and capitalise Amulet. This is what the user sees.
Add "installer" suffix to the volume name to help distinguish it from the app