### PR TITLE
Make flatpak build behave like pyinstaller build

### DIFF
--- a/amulet_map_editor/api/framework/amulet_ui.py
+++ b/amulet_map_editor/api/framework/amulet_ui.py
@@ -5,6 +5,7 @@ from typing import Dict, Union
 import traceback
 import logging
 import sys
+import os
 
 from amulet.api.errors import LoaderNoneMatched
 from amulet_map_editor.api.wx.ui.select_world import open_level_from_dialog
@@ -39,7 +40,7 @@ class AmuletUI(wx.Frame):
 
     def __init__(self, parent):
         title = f"Amulet {__version__}"
-        if not getattr(sys, "frozen", False):
+        if not (getattr(sys, "frozen", False) or os.path.exists("/.flatpak-info")):
             title += " (source)"
         wx.Frame.__init__(
             self,

--- a/amulet_map_editor/api/framework/app.py
+++ b/amulet_map_editor/api/framework/app.py
@@ -4,6 +4,7 @@ import sys
 import locale
 import logging
 import time
+import os
 
 from amulet_map_editor.api import config
 from amulet_map_editor import __version__
@@ -35,7 +36,7 @@ class AmuletApp(wx.App):
 
         meta_config = config.get("amulet_meta", {})
 
-        if not getattr(sys, "frozen", False):
+        if not (getattr(sys, "frozen", False) or os.path.exists("/.flatpak-info")):
             licence_dialog_show_time = meta_config.get("licence_dialog_show_time", 0)
             if licence_dialog_show_time < time.time() - 3600 * 24 * 30:
                 # Last shown more than a month ago


### PR DESCRIPTION
Don't show the licence dialog or source label when installed as a flatpak