### PR TITLE
Add a link to the website

### DIFF
--- a/amulet_app.exe.txt
+++ b/amulet_app.exe.txt
@@ -1,0 +1,1 @@
+New versions of Amulet can be bought from https://www.amuletmc.com


### PR DESCRIPTION
A number of users have downloaded the source code and wondered why they can't find the app.
This adds a text file that looks like the app to direct people to the website.