### PR TITLE
Disable Python's faulthandler by default

### DIFF
--- a/amulet_map_editor/__main__.py
+++ b/amulet_map_editor/__main__.py
@@ -110,7 +110,7 @@ def _init_log() -> logging.Logger:
 
     threading.excepthook = thread_error_handler
 
-    if "--disable-py-faulthandler" not in sys.argv:
+    if "--enable-py-faulthandler" in sys.argv:
         # When running via pythonw the stderr is None so log directly to the log file
         faulthandler.enable(log_file)
 


### PR DESCRIPTION
A number of users have reported access violations within Python's faulthandler which crash the application.
This is now disabled by default.