### PR TITLE
Fix alert sound on macOS

### DIFF
--- a/amulet_map_editor/api/opengl/canvas/event_canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/event_canvas.py
@@ -25,6 +25,7 @@ class EventCanvas(BaseCanvas):
         """Unbind all events.
         We are allowing users to bind custom events so we should have a way to reset what is bound.
         """
+        # Disconnect all handlers
         for event, data in self._bound_events.items():
             for handler, source in data:
                 if source is None:
@@ -42,15 +43,49 @@ class EventCanvas(BaseCanvas):
 
     def Bind(self, event, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
         """Bind an event to the canvas."""
-        self._bound_events.setdefault(event, []).append((handler, source))
-        super().Bind(event, handler, source, id, id2)
+        # Store the event handler and source
+        event_group = self._bound_events.setdefault(event, [])
+        event_group.append((handler, source))
+
+        if event == wx.EVT_KEY_DOWN:
+            # If this is the first key down handler, bind the key down event
+            if len(event_group) == 1:
+                super().Bind(wx.EVT_KEY_DOWN, self._on_key_down)
+        else:
+            super().Bind(event, handler, source, id, id2)
 
     def Unbind(
         self, event, source=None, id=wx.ID_ANY, id2=wx.ID_ANY, handler=None
     ) -> bool:
         """Unbind an event from the canvas."""
         try:
-            self._bound_events[event].remove((handler, source))
+            # Try and remove the event handler and source
+            event_group = self._bound_events[event]
+            event_group.remove((handler, source))
         except (KeyError, ValueError):
             pass
+        else:
+            # If there are no more handlers for the key down event, unbind it
+            if event == wx.EVT_KEY_DOWN and not event_group:
+                super().Unbind(wx.EVT_KEY_DOWN, self._on_key_down)
+                return True
+
+        # Remove the handler
         return super().Unbind(event, source=source, id=id, id2=id2, handler=handler)
+
+    def _on_key_down(self, evt: wx.KeyEvent) -> None:
+        # On macOS if no handler claims the key down event, an alert sound will play.
+        # To get around this, we must have one handler and skip if no handler claims the event.
+        handled = False
+        for handler, source in self._bound_events.get(wx.EVT_KEY_DOWN, []):
+            if source is not None and source != evt.GetEventObject():
+                continue
+            evt.Skip(False)
+            try:
+                handler(evt)
+            except Exception as e:
+                log.exception(f"Failed to handle key down event: {e}")
+            if not evt.GetSkipped():
+                handled = True
+        if not handled:
+            evt.Skip()

--- a/amulet_map_editor/api/opengl/canvas/event_canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/event_canvas.py
@@ -1,5 +1,5 @@
 import wx
-from typing import List, Tuple, Any
+from typing import Any
 import logging
 
 from amulet_map_editor.api.opengl.canvas import BaseCanvas
@@ -11,7 +11,7 @@ class EventCanvas(BaseCanvas):
     """A modification of the normal canvas to make it easier to add and remove events."""
 
     def __init__(self, parent: wx.Window):
-        self._bound_events: List[Tuple[wx.PyEventBinder, Any, Any]] = []
+        self._bound_events: dict[wx.PyEventBinder, list[tuple[Any, Any]]] = {}
         super().__init__(parent)
 
     def reset_bound_events(self):
@@ -25,13 +25,14 @@ class EventCanvas(BaseCanvas):
         """Unbind all events.
         We are allowing users to bind custom events so we should have a way to reset what is bound.
         """
-        for event, handler, source in self._bound_events:
-            if source is None:
-                while super().Unbind(event):
-                    pass
-            else:
-                if not self.Unbind(event, source, handler=handler):
-                    log.error(f"Failed to unbind {event}, {handler}, {source}")
+        for event, data in self._bound_events.items():
+            for handler, source in data:
+                if source is None:
+                    while super().Unbind(event):
+                        pass
+                else:
+                    if not self.Unbind(event, source, handler=handler):
+                        log.error(f"Failed to unbind {event}, {handler}, {source}")
         self._bound_events.clear()
 
     def bind_events(self):
@@ -41,14 +42,15 @@ class EventCanvas(BaseCanvas):
 
     def Bind(self, event, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
         """Bind an event to the canvas."""
-        self._bound_events.append((event, handler, source))
+        self._bound_events.setdefault(event, []).append((handler, source))
         super().Bind(event, handler, source, id, id2)
 
     def Unbind(
         self, event, source=None, id=wx.ID_ANY, id2=wx.ID_ANY, handler=None
     ) -> bool:
         """Unbind an event from the canvas."""
-        key = (event, handler, source)
-        if key in self._bound_events:
-            self._bound_events.remove(key)
+        try:
+            self._bound_events[event].remove((handler, source))
+        except (KeyError, ValueError):
+            pass
         return super().Unbind(event, source=source, id=id, id2=id2, handler=handler)

--- a/amulet_map_editor/api/opengl/canvas/event_canvas.py
+++ b/amulet_map_editor/api/opengl/canvas/event_canvas.py
@@ -87,5 +87,4 @@ class EventCanvas(BaseCanvas):
                 log.exception(f"Failed to handle key down event: {e}")
             if not evt.GetSkipped():
                 handled = True
-        if not handled:
-            evt.Skip()
+        evt.Skip(not handled)

--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -220,7 +220,8 @@ class ButtonInput(WindowContainer):
                 wx.PostEvent(self.window, InputPressEvent(action_id))
 
             self._pressed_keys.add(key)
-            return
+            if action_ids:
+                return
         evt.Skip()
 
     def _release(self, evt):

--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -207,22 +207,20 @@ class ButtonInput(WindowContainer):
             and action.modifier_keys.issubset(self._pressed_keys)
         )
 
-    def _press(self, evt: wx.KeyEvent):
+    def _press(self, evt: wx.KeyEvent | wx.MouseEvent | wx.NavigationKeyEvent):
         """Event to handle a number of different key presses"""
         key = serialise_key(evt)
         if key is None:
             evt.Skip()
             return
+        action_ids = self._find_actions(key)
         if not self.is_key_pressed(key):
-            action_ids = self._find_actions(key)
             self._continuous_actions.update(action_ids)
             for action_id in action_ids:
                 wx.PostEvent(self.window, InputPressEvent(action_id))
-
             self._pressed_keys.add(key)
-            if action_ids:
-                return
-        evt.Skip()
+        if not (isinstance(evt, wx.KeyEvent) and action_ids):
+            evt.Skip()
 
     def _release(self, evt):
         """Event to handle a number of different key releases"""

--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -211,6 +211,7 @@ class ButtonInput(WindowContainer):
         """Event to handle a number of different key presses"""
         key = serialise_key(evt)
         if key is None:
+            evt.Skip()
             return
         if not self.is_key_pressed(key):
             action_ids = self._find_actions(key)
@@ -219,7 +220,7 @@ class ButtonInput(WindowContainer):
                 wx.PostEvent(self.window, InputPressEvent(action_id))
 
             self._pressed_keys.add(key)
-        evt.StopPropagation()
+            return
         evt.Skip()
 
     def _release(self, evt):

--- a/amulet_map_editor/api/wx/util/button_input.py
+++ b/amulet_map_editor/api/wx/util/button_input.py
@@ -207,7 +207,7 @@ class ButtonInput(WindowContainer):
             and action.modifier_keys.issubset(self._pressed_keys)
         )
 
-    def _press(self, evt):
+    def _press(self, evt: wx.KeyEvent):
         """Event to handle a number of different key presses"""
         key = serialise_key(evt)
         if key is None:
@@ -219,6 +219,7 @@ class ButtonInput(WindowContainer):
                 wx.PostEvent(self.window, InputPressEvent(action_id))
 
             self._pressed_keys.add(key)
+        evt.StopPropagation()
         evt.Skip()
 
     def _release(self, evt):

--- a/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
@@ -248,7 +248,7 @@ class BlockSelectionBehaviour(PointerBehaviour):
         key = evt.GetUnicodeKey() or evt.GetKeyCode()
         if key == wx.WXK_ESCAPE:
             self._escape()
-            evt.StopPropagation()
+            return
         evt.Skip()
 
     def _on_input_release(self, evt: InputReleaseEvent):

--- a/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/block_selection_behaviour.py
@@ -248,6 +248,7 @@ class BlockSelectionBehaviour(PointerBehaviour):
         key = evt.GetUnicodeKey() or evt.GetKeyCode()
         if key == wx.WXK_ESCAPE:
             self._escape()
+            evt.StopPropagation()
         evt.Skip()
 
     def _on_input_release(self, evt: InputReleaseEvent):

--- a/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
@@ -55,7 +55,7 @@ class CameraBehaviour(BaseBehaviour):
         key = evt.GetUnicodeKey() or evt.GetKeyCode()
         if key == wx.WXK_ESCAPE:
             self._escape()
-            evt.StopPropagation()
+            return
         evt.Skip()
 
     def _on_input_press(self, evt: InputPressEvent):

--- a/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
+++ b/amulet_map_editor/programs/edit/api/behaviour/camera_behaviour.py
@@ -55,6 +55,7 @@ class CameraBehaviour(BaseBehaviour):
         key = evt.GetUnicodeKey() or evt.GetKeyCode()
         if key == wx.WXK_ESCAPE:
             self._escape()
+            evt.StopPropagation()
         evt.Skip()
 
     def _on_input_press(self, evt: InputPressEvent):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ include_package_data = True
 python_requires = >=3.11
 install_requires =
     Pillow>=10.0.1
-    wxPython~=4.2.5
+    wxPython~=4.2.0
     numpy~=1.17
     pyopengl~=3.0
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ include_package_data = True
 python_requires = >=3.11
 install_requires =
     Pillow>=10.0.1
-    wxPython
+    wxPython~=4.2.5
     numpy~=1.17
     pyopengl~=3.0
     packaging


### PR DESCRIPTION
Refactor key press handling to correctly capture key presses.
Only key presses that are not used by the program are skipped.
This stops macOS making a beeping sound when pressing valid keys.

Fixes #1152 