### PR TITLE
Fix layout issues

### DIFF
--- a/amulet_map_editor/api/wx/ui/base_define.py
+++ b/amulet_map_editor/api/wx/ui/base_define.py
@@ -26,16 +26,16 @@ class BaseDefine(wx.Panel):
         show_pick: bool = False,
         **kwargs,
     ):
-        super().__init__(parent)
+        super().__init__(parent, style=wx.TAB_TRAVERSAL | wx.BORDER_SIMPLE)
 
         self._translation_manager = translation_manager
         self._orientation = orientation
         self._sizer = wx.BoxSizer(orientation)
         left_sizer = wx.BoxSizer(wx.VERTICAL)
         if orientation == wx.HORIZONTAL:
-            self._sizer.Add(left_sizer, 1, wx.EXPAND)
+            self._sizer.Add(left_sizer, 1, wx.EXPAND | wx.ALL, 5)
         else:
-            self._sizer.Add(left_sizer, 1, wx.EXPAND)
+            self._sizer.Add(left_sizer, 1, wx.EXPAND | wx.ALL, 5)
 
         self._version_picker = VersionSelect(
             self,

--- a/amulet_map_editor/api/wx/ui/base_define.py
+++ b/amulet_map_editor/api/wx/ui/base_define.py
@@ -60,8 +60,7 @@ class BaseDefine(wx.Panel):
         left_sizer.Add(self._picker, 1, wx.EXPAND | wx.TOP, 5)
         self._picker.Bind(EVT_ITEM_CHANGE, self._on_picker_change)
 
-        self.SetSizerAndFit(self._sizer)
-        self.Layout()
+        self.SetSizer(self._sizer)
 
     def _on_picker_change(self, evt):
         raise NotImplementedError("This method should be overridden in child classes.")

--- a/amulet_map_editor/api/wx/ui/base_define.py
+++ b/amulet_map_editor/api/wx/ui/base_define.py
@@ -35,7 +35,7 @@ class BaseDefine(wx.Panel):
         if orientation == wx.HORIZONTAL:
             self._sizer.Add(left_sizer, 1, wx.EXPAND)
         else:
-            self._sizer.Add(left_sizer, 2, wx.EXPAND)
+            self._sizer.Add(left_sizer, 1, wx.EXPAND)
 
         self._version_picker = VersionSelect(
             self,

--- a/amulet_map_editor/api/wx/ui/base_select.py
+++ b/amulet_map_editor/api/wx/ui/base_select.py
@@ -50,12 +50,15 @@ class BaseSelect(wx.Panel):
         self._version_number: Optional[Tuple[int, int, int]] = None
         self._force_blockstate: Optional[bool] = force_blockstate
 
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self._sizer.Add(sizer, 0, wx.EXPAND | wx.ALL, 5)
+        self._grid_sizer = wx.FlexGridSizer(2, 5, 5)
+        self._grid_sizer.AddGrowableCol(0, proportion=0)
+        self._grid_sizer.AddGrowableCol(1, proportion=1)
+        self._sizer.Add(self._grid_sizer, 0, wx.EXPAND | wx.ALL, 5)
+
         text = wx.StaticText(self, label="Namespace:", style=wx.ALIGN_CENTER)
-        sizer.Add(text, 1, wx.ALIGN_CENTER_VERTICAL)
+        self._grid_sizer.Add(text, 0, wx.ALIGN_CENTER_VERTICAL)
         self._namespace_combo = wx.ComboBox(self)
-        sizer.Add(self._namespace_combo, 2)
+        self._grid_sizer.Add(self._namespace_combo, 1, wx.EXPAND)
         self._set_version((platform, version_number, force_blockstate or False))
         self._populate_namespace()
         self.set_namespace(namespace)
@@ -68,11 +71,7 @@ class BaseSelect(wx.Panel):
         )
 
         self.Bind(EVT_ITEM_NAMESPACE_CHANGE, self._on_namespace_change)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        self._sizer.Add(sizer, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
-        header_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(header_sizer, 0, wx.EXPAND | wx.BOTTOM, 5)
-        header_sizer.Add(
+        self._grid_sizer.Add(
             wx.StaticText(
                 self, label=f"{self.TypeName.capitalize()} name:", style=wx.ALIGN_CENTER
             ),
@@ -80,19 +79,19 @@ class BaseSelect(wx.Panel):
             wx.ALIGN_CENTER_VERTICAL,
         )
         search_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        header_sizer.Add(search_sizer, 2, wx.EXPAND)
+        self._grid_sizer.Add(search_sizer, 1, wx.EXPAND)
         self._search = wx.SearchCtrl(self)
         search_sizer.Add(self._search, 1, wx.ALIGN_CENTER_VERTICAL)
         self._search.Bind(wx.EVT_TEXT, self._on_search_change)
         if show_pick:
-            pick_button = wx.BitmapButton(self, bitmap=COLOUR_PICKER.bitmap(22, 22))
+            pick_button = wx.BitmapButton(self, bitmap=COLOUR_PICKER.bitmap(20, 20))
             search_sizer.Add(pick_button, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 5)
             pick_button.Bind(
                 wx.EVT_BUTTON,
                 lambda evt: wx.PostEvent(self, PickEvent(self.GetId(), widget=self)),
             )
         self._list_box = wx.ListBox(self, style=wx.LB_SINGLE)
-        sizer.Add(self._list_box, 1, wx.EXPAND)
+        self._sizer.Add(self._list_box, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         self._names: List[str] = []
         self._populate_item_name()

--- a/amulet_map_editor/api/wx/ui/base_select.py
+++ b/amulet_map_editor/api/wx/ui/base_select.py
@@ -92,7 +92,9 @@ class BaseSelect(wx.Panel):
             )
         self._list_box = wx.ListBox(self, style=wx.LB_SINGLE)
         self._list_box.SetMinSize(wx.Size(-1, 100))
-        self._sizer.Add(self._list_box, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+        self._sizer.Add(
+            self._list_box, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+        )
 
         self._names: List[str] = []
         self._populate_item_name()

--- a/amulet_map_editor/api/wx/ui/base_select.py
+++ b/amulet_map_editor/api/wx/ui/base_select.py
@@ -91,6 +91,7 @@ class BaseSelect(wx.Panel):
                 lambda evt: wx.PostEvent(self, PickEvent(self.GetId(), widget=self)),
             )
         self._list_box = wx.ListBox(self, style=wx.LB_SINGLE)
+        self._list_box.SetMinSize(wx.Size(-1, 100))
         self._sizer.Add(self._list_box, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         self._names: List[str] = []

--- a/amulet_map_editor/api/wx/ui/block_select/block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/block_define.py
@@ -70,9 +70,6 @@ class BlockDefine(BaseDefine):
         right_sizer.Add(self._property_picker, 1, wx.EXPAND)
         self._property_picker.Bind(EVT_PROPERTIES_CHANGE, self._on_property_change)
 
-        self.SetSizerAndFit(self._sizer)
-        self.Layout()
-
     def _on_picker_change(self, evt):
         self._update_properties()
         evt.Skip()

--- a/amulet_map_editor/api/wx/ui/block_select/block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/block_define.py
@@ -13,7 +13,6 @@ from amulet_map_editor.api.wx.ui.block_select import BlockSelect
 from amulet_map_editor.api.wx.ui.block_select.properties import (
     PropertySelect,
     WildcardSNBTType,
-    EVT_PROPERTIES_CHANGE,
 )
 
 
@@ -68,14 +67,9 @@ class BlockDefine(BaseDefine):
             wildcard_properties,
         )
         right_sizer.Add(self._property_picker, 1, wx.EXPAND)
-        self._property_picker.Bind(EVT_PROPERTIES_CHANGE, self._on_property_change)
 
     def _on_picker_change(self, evt):
         self._update_properties()
-        evt.Skip()
-
-    def _on_property_change(self, evt):
-        self.Layout()
         evt.Skip()
 
     def _update_properties(self):
@@ -159,19 +153,70 @@ class BlockDefine(BaseDefine):
 if __name__ == "__main__":
 
     def main():
-        app = wx.App()
+        from amulet_map_editor.api.wx.ui.block_select.properties import (
+            EVT_PROPERTIES_CHANGE,
+        )
+        from amulet_map_editor.api.wx.ui.widget_size_changed import EVT_WIDGET_SIZE_CHANGED
+        from amulet_map_editor.api.wx.ui.simple import SimpleScrollablePanel
+
         translation_manager = PyMCTranslate.new_translation_manager()
+
+        class Replace(SimpleScrollablePanel):
+            def __init__(self, parent: wx.Window):
+                SimpleScrollablePanel.__init__(self, parent)
+
+                self._original_block = BlockDefine(
+                    self,
+                    translation_manager,
+                    wx.VERTICAL,
+                    wildcard_properties=True,
+                    show_pick_block=True,
+                )
+                self._sizer.Add(self._original_block, 0, wx.EXPAND)
+                self._replacement_block = BlockDefine(
+                    self, translation_manager, wx.VERTICAL, show_pick_block=True
+                )
+                self._sizer.Add(self._replacement_block, 0, wx.TOP | wx.EXPAND, 10)
+
+            def DoGetBestClientSize(self):
+                sizer = self.GetSizer()
+                if sizer is None:
+                    return -1, -1
+                else:
+                    sx, sy = self.GetSizer().CalcMin()
+                    return (
+                        sx + wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X),
+                        sy + wx.SystemSettings.GetMetric(wx.SYS_HSCROLL_Y),
+                    )
+
+        app = wx.App()
+
         dialog = wx.Dialog(None, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
-        sizer = wx.BoxSizer()
-        dialog.SetSizer(sizer)
-        sizer.Add(
-            BlockDefine(dialog, translation_manager, wx.HORIZONTAL),
-            1,
+        sizer_h = wx.BoxSizer(wx.HORIZONTAL)
+        dialog.SetSizer(sizer_h)
+        sizer_v = wx.BoxSizer(wx.VERTICAL)
+        sizer_h.Add(sizer_v, 0, wx.EXPAND)
+        sizer_v.Add(
+            Replace(dialog),
+            # BlockDefine(dialog, translation_manager, show_pick_block=True),
+            0,
             wx.ALL | wx.EXPAND,
             5,
         )
         dialog.Show()
         dialog.Fit()
+
+        def on_properties_change(evt):
+            print("Properties changed:", evt.properties)
+
+        dialog.Bind(EVT_PROPERTIES_CHANGE, on_properties_change)
+
+        def on_layout_change(evt):
+            dialog.Layout()
+            evt.Skip()
+
+        dialog.Bind(EVT_WIDGET_SIZE_CHANGED, on_layout_change)
+
         app.MainLoop()
 
     main()

--- a/amulet_map_editor/api/wx/ui/block_select/block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/block_define.py
@@ -49,9 +49,9 @@ class BlockDefine(BaseDefine):
 
         right_sizer = wx.BoxSizer(wx.VERTICAL)
         if orientation == wx.HORIZONTAL:
-            self._sizer.Add(right_sizer, 1, wx.EXPAND | wx.LEFT, 5)
+            self._sizer.Add(right_sizer, 1, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 5)
         else:
-            self._sizer.Add(right_sizer, 0, wx.EXPAND | wx.TOP, 5)
+            self._sizer.Add(right_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
         self._property_picker = PropertySelect(
             self,

--- a/amulet_map_editor/api/wx/ui/block_select/block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/block_define.py
@@ -51,7 +51,7 @@ class BlockDefine(BaseDefine):
         if orientation == wx.HORIZONTAL:
             self._sizer.Add(right_sizer, 1, wx.EXPAND | wx.LEFT, 5)
         else:
-            self._sizer.Add(right_sizer, 1, wx.EXPAND | wx.TOP, 5)
+            self._sizer.Add(right_sizer, 0, wx.EXPAND | wx.TOP, 5)
 
         self._property_picker = PropertySelect(
             self,

--- a/amulet_map_editor/api/wx/ui/block_select/block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/block_define.py
@@ -48,9 +48,13 @@ class BlockDefine(BaseDefine):
 
         right_sizer = wx.BoxSizer(wx.VERTICAL)
         if orientation == wx.HORIZONTAL:
-            self._sizer.Add(right_sizer, 1, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 5)
+            self._sizer.Add(
+                right_sizer, 1, wx.EXPAND | wx.TOP | wx.RIGHT | wx.BOTTOM, 5
+            )
         else:
-            self._sizer.Add(right_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+            self._sizer.Add(
+                right_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+            )
 
         self._property_picker = PropertySelect(
             self,
@@ -156,7 +160,9 @@ if __name__ == "__main__":
         from amulet_map_editor.api.wx.ui.block_select.properties import (
             EVT_PROPERTIES_CHANGE,
         )
-        from amulet_map_editor.api.wx.ui.widget_size_changed import EVT_WIDGET_SIZE_CHANGED
+        from amulet_map_editor.api.wx.ui.widget_size_changed import (
+            EVT_WIDGET_SIZE_CHANGED,
+        )
         from amulet_map_editor.api.wx.ui.simple import SimpleScrollablePanel
 
         translation_manager = PyMCTranslate.new_translation_manager()

--- a/amulet_map_editor/api/wx/ui/block_select/multi_block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/multi_block_define.py
@@ -36,8 +36,7 @@ class MultiBlockDefine(wx.lib.scrolledpanel.ScrolledPanel):
             self._block_picker_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
         )
 
-        self.SetSizerAndFit(self._sizer)
-        self.Layout()
+        self.SetSizer(self._sizer)
 
         self._add_button.Bind(wx.EVT_BUTTON, self._add)
         self._fix_enabled_buttons()

--- a/amulet_map_editor/api/wx/ui/block_select/multi_block_define.py
+++ b/amulet_map_editor/api/wx/ui/block_select/multi_block_define.py
@@ -13,6 +13,7 @@ from amulet_map_editor.api.image import (
     MINIMIZE,
 )
 from amulet_map_editor.api.wx.ui.block_select import BlockDefine, EVT_PROPERTIES_CHANGE
+from amulet_map_editor.api.wx.ui.widget_size_changed import WidgetSizeChangeEvent
 
 
 class MultiBlockDefine(wx.lib.scrolledpanel.ScrolledPanel):
@@ -164,7 +165,7 @@ class _CollapsibleBlockDefine(wx.Panel):
         else:
             self.expand_button.SetBitmap(self.COLLAPSE)
             self.block_define.Show()
-        self.TopLevelParent.Layout()
+        wx.PostEvent(self, WidgetSizeChangeEvent(self.GetId()))
 
     def _toggle_block_expand(self, parent: MultiBlockDefine):
         if self.collapsed:
@@ -173,7 +174,6 @@ class _CollapsibleBlockDefine(wx.Panel):
 
     def _on_properties_change(self, evt):
         self.block_label.SetLabel(self._gen_block_string())
-        self.TopLevelParent.Layout()
         evt.Skip()
 
     def _gen_block_string(self):

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -151,8 +151,8 @@ class PropertySelect(wx.Panel):
             self.Show()
         else:
             specification = translator.get_specification(
-                    self._namespace, self._block_name, self._force_blockstate
-                )
+                self._namespace, self._block_name, self._force_blockstate
+            )
             self._simple.Show()
             self._simple.set_specification(specification)
             self._manual.Hide()
@@ -179,9 +179,7 @@ class SimplePropertySelect(wx.Panel):
         self._property_sizer = wx.FlexGridSizer(2, 5, 5)
         self._property_sizer.AddGrowableCol(0, proportion=0)
         self._property_sizer.AddGrowableCol(1, proportion=1)
-        sizer.Add(
-            self._property_sizer, 0, wx.EXPAND | wx.ALL, 5
-        )
+        sizer.Add(self._property_sizer, 0, wx.EXPAND | wx.ALL, 5)
 
         self._properties: Dict[str, wx.Choice] = {}
         self._specification: dict = {}
@@ -209,9 +207,7 @@ class SimplePropertySelect(wx.Panel):
 
         label = wx.StaticText(self, label="Property Name", style=wx.ALIGN_CENTER)
         self._property_sizer.Add(label, 0, wx.ALIGN_CENTER)
-        label = wx.StaticText(
-            self, label="Value (SNBT)", style=wx.ALIGN_CENTER
-        )
+        label = wx.StaticText(self, label="Value (SNBT)", style=wx.ALIGN_CENTER)
         self._property_sizer.Add(label, 0, wx.ALIGN_CENTER)
 
         for name, choices in spec_properties.items():

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -148,14 +148,15 @@ class PropertySelect(wx.Panel):
         if self._manual_enabled:
             self._simple.Hide()
             self._manual.Show()
+            self.Show()
         else:
-            self._simple.Show()
-            self._simple.set_specification(
-                translator.get_specification(
+            specification = translator.get_specification(
                     self._namespace, self._block_name, self._force_blockstate
                 )
-            )
+            self._simple.Show()
+            self._simple.set_specification(specification)
             self._manual.Hide()
+            self.Show(bool(specification.get("properties", {})))
         self.Thaw()
 
 

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -174,17 +174,11 @@ class SimplePropertySelect(wx.Panel):
         self.SetSizer(sizer)
         self._translation_manager = translation_manager
 
-        header_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(header_sizer, 0, wx.EXPAND | wx.ALL, 5)
-        label = wx.StaticText(self, label="Property Name", style=wx.ALIGN_CENTER)
-        header_sizer.Add(label, 1)
-        label = wx.StaticText(
-            self, label="Property Value (SNBT)", style=wx.ALIGN_CENTER
-        )
-        header_sizer.Add(label, 1, wx.LEFT, 5)
-        self._property_sizer = wx.GridSizer(2, 5, 5)
+        self._property_sizer = wx.FlexGridSizer(2, 5, 5)
+        self._property_sizer.AddGrowableCol(0, proportion=0)
+        self._property_sizer.AddGrowableCol(1, proportion=1)
         sizer.Add(
-            self._property_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+            self._property_sizer, 0, wx.EXPAND | wx.ALL, 5
         )
 
         self._properties: Dict[str, wx.Choice] = {}
@@ -210,6 +204,13 @@ class SimplePropertySelect(wx.Panel):
             "properties", {}
         )
         spec_defaults = self._specification.get("defaults", {})
+
+        label = wx.StaticText(self, label="Property Name", style=wx.ALIGN_CENTER)
+        self._property_sizer.Add(label, 0, wx.ALIGN_CENTER)
+        label = wx.StaticText(
+            self, label="Value (SNBT)", style=wx.ALIGN_CENTER
+        )
+        self._property_sizer.Add(label, 0, wx.ALIGN_CENTER)
 
         for name, choices in spec_properties.items():
             label = wx.StaticText(self, label=name)

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -175,7 +175,7 @@ class SimplePropertySelect(wx.Panel):
         self._translation_manager = translation_manager
 
         header_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(header_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+        sizer.Add(header_sizer, 0, wx.EXPAND | wx.ALL, 5)
         label = wx.StaticText(self, label="Property Name", style=wx.ALIGN_CENTER)
         header_sizer.Add(label, 1)
         label = wx.StaticText(
@@ -183,7 +183,9 @@ class SimplePropertySelect(wx.Panel):
         )
         header_sizer.Add(label, 1, wx.LEFT, 5)
         self._property_sizer = wx.GridSizer(2, 5, 5)
-        sizer.Add(self._property_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        sizer.Add(
+            self._property_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5
+        )
 
         self._properties: Dict[str, wx.Choice] = {}
         self._specification: dict = {}
@@ -254,7 +256,7 @@ class ManualPropertySelect(wx.Panel):
             self, bitmap=ADD_ICON.bitmap(30, 30), size=(30, 30)
         )
         header_sizer.Add(add_button)
-        sizer.Add(header_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+        sizer.Add(header_sizer, 0, wx.EXPAND | wx.ALL, 5)
         label = wx.StaticText(self, label="Property Name", style=wx.ALIGN_CENTER)
         header_sizer.Add(label, 1, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 5)
         label = wx.StaticText(
@@ -264,9 +266,7 @@ class ManualPropertySelect(wx.Panel):
         header_sizer.AddStretchSpacer(1)
 
         self._property_sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(
-            self._property_sizer, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5
-        )
+        sizer.Add(self._property_sizer, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 5)
 
         add_button.Bind(wx.EVT_BUTTON, lambda evt: self._add_property())
 
@@ -300,7 +300,7 @@ class ManualPropertySelect(wx.Panel):
         self._change_value("", snbt_text)
         value_entry.Bind(wx.EVT_TEXT, lambda evt: self._on_value_change(evt, snbt_text))
 
-        self._property_sizer.Add(sizer, 1, wx.TOP | wx.EXPAND, 5)
+        self._property_sizer.Add(sizer, 0, wx.BOTTOM | wx.EXPAND, 5)
         self._properties[self._property_index] = (name_entry, value_entry)
         self.Fit()
         self.TopLevelParent.Layout()

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -333,12 +333,14 @@ class ManualPropertySelect(wx.Panel):
 
     def _on_remove_property(self, sizer: wx.Sizer, key: int):
         self.Freeze()
-        self._property_sizer.Detach(sizer)
-        sizer.Clear(True)
-        del self._properties[key]
-        self.TopLevelParent.Layout()
-        self.Thaw()
-        self._post_property_change()
+        try:
+            self._property_sizer.Detach(sizer)
+            sizer.Clear(True)
+            del self._properties[key]
+            self.TopLevelParent.Layout()
+            self._post_property_change()
+        finally:
+            self.Thaw()
 
     @property
     def properties(self) -> Dict[str, SNBTType]:

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -11,6 +11,7 @@ from amulet.api.block import PropertyDataTypes, PropertyType
 WildcardSNBTType = Union[SNBTType, str]
 
 from amulet_map_editor.api.image import ADD_ICON, SUBTRACT_ICON
+from amulet_map_editor.api.wx.ui.widget_size_changed import WidgetSizeChangeEvent
 
 (
     PropertiesChangeEvent,
@@ -133,7 +134,6 @@ class PropertySelect(wx.Panel):
             self._manual.properties = properties
         else:
             self._simple.properties = properties
-        self.TopLevelParent.Layout()
         self.Thaw()
 
     def _set_ui(self):
@@ -157,6 +157,10 @@ class PropertySelect(wx.Panel):
             self._simple.set_specification(specification)
             self._manual.Hide()
             self.Show(bool(specification.get("properties", {})))
+        wx.PostEvent(
+            self,
+            WidgetSizeChangeEvent(self.GetId()),
+        )
         self.Thaw()
 
 
@@ -237,11 +241,13 @@ class SimplePropertySelect(wx.Panel):
                 choice.SetSelection(choices.index(val))
             self._properties[name] = choice
         self.Thaw()
-        self.Fit()
-        self.Layout()
         wx.PostEvent(
             self,
             PropertiesChangeEvent(self.GetId(), properties=self.properties),
+        )
+        wx.PostEvent(
+            self,
+            WidgetSizeChangeEvent(self.GetId()),
         )
 
 
@@ -281,6 +287,9 @@ class ManualPropertySelect(wx.Panel):
             self, PropertiesChangeEvent(self.GetId(), properties=self.properties)
         )
 
+    def _post_layout_change(self) -> None:
+        wx.PostEvent(self, WidgetSizeChangeEvent(self.GetId()))
+
     def _add_property(self, name: str = "", value: SNBTType = "", events=True):
         self.Freeze()
         sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -305,8 +314,6 @@ class ManualPropertySelect(wx.Panel):
 
         self._property_sizer.Add(sizer, 0, wx.BOTTOM | wx.EXPAND, 5)
         self._properties[self._property_index] = (name_entry, value_entry)
-        self.Fit()
-        self.TopLevelParent.Layout()
         self.Thaw()
         if events:
             self._post_property_change()
@@ -341,8 +348,8 @@ class ManualPropertySelect(wx.Panel):
             self._property_sizer.Detach(sizer)
             sizer.Clear(True)
             del self._properties[key]
-            self.TopLevelParent.Layout()
             self._post_property_change()
+            self._post_layout_change()
         finally:
             self.Thaw()
 
@@ -366,6 +373,7 @@ class ManualPropertySelect(wx.Panel):
         for name, value in properties.items():
             self._add_property(name, value, False)
         self._post_property_change()
+        self._post_layout_change()
 
 
 if __name__ == "__main__":

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -317,6 +317,7 @@ class ManualPropertySelect(wx.Panel):
         evt.Skip()
 
     def _change_value(self, snbt: SNBTType, snbt_text: wx.StaticText):
+        self.Freeze()
         try:
             nbt = amulet_nbt.from_snbt(snbt)
         except:
@@ -329,7 +330,9 @@ class ManualPropertySelect(wx.Panel):
             else:
                 snbt_text.SetLabel(f"{nbt.__class__.__name__} not valid")
                 snbt_text.SetBackgroundColour((255, 200, 200))
-        self.Layout()
+        finally:
+            self.Layout()
+            self.Thaw()
 
     def _on_remove_property(self, sizer: wx.Sizer, key: int):
         self.Freeze()

--- a/amulet_map_editor/api/wx/ui/block_select/properties.py
+++ b/amulet_map_editor/api/wx/ui/block_select/properties.py
@@ -109,9 +109,6 @@ class PropertySelect(wx.Panel):
     @str_properties.setter
     def str_properties(self, properties: Dict[str, WildcardSNBTType]):
         self.set_properties(properties)
-        wx.PostEvent(
-            self, PropertiesChangeEvent(self.GetId(), properties=self.str_properties)
-        )
 
     @property
     def properties(self) -> PropertyType:
@@ -241,6 +238,10 @@ class SimplePropertySelect(wx.Panel):
         self.Thaw()
         self.Fit()
         self.Layout()
+        wx.PostEvent(
+            self,
+            PropertiesChangeEvent(self.GetId(), properties=self.properties),
+        )
 
 
 class ManualPropertySelect(wx.Panel):
@@ -279,7 +280,7 @@ class ManualPropertySelect(wx.Panel):
             self, PropertiesChangeEvent(self.GetId(), properties=self.properties)
         )
 
-    def _add_property(self, name: str = "", value: SNBTType = ""):
+    def _add_property(self, name: str = "", value: SNBTType = "", events=True):
         self.Freeze()
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         self._property_index += 1
@@ -306,6 +307,9 @@ class ManualPropertySelect(wx.Panel):
         self.Fit()
         self.TopLevelParent.Layout()
         self.Thaw()
+        if events:
+            self._post_property_change()
+            self._post_layout_change()
 
     def _on_value_change(self, evt, snbt_text: wx.StaticText):
         self._change_value(evt.GetString(), snbt_text)
@@ -354,7 +358,8 @@ class ManualPropertySelect(wx.Panel):
         self._properties.clear()
         self._property_index = 0
         for name, value in properties.items():
-            self._add_property(name, value)
+            self._add_property(name, value, False)
+        self._post_property_change()
 
 
 if __name__ == "__main__":

--- a/amulet_map_editor/api/wx/ui/simple.py
+++ b/amulet_map_editor/api/wx/ui/simple.py
@@ -39,7 +39,7 @@ class SimpleScrollablePanel(ScrolledPanel, SimpleSizer):
         SimpleSizer.__init__(self, sizer_dir)
         self.SetSizer(self.sizer)
         self.SetupScrolling()
-        self.SetAutoLayout(1)
+        self.SetAutoLayout(True)
 
     def DoGetBestSize(self):
         sizer = self.GetSizer()

--- a/amulet_map_editor/api/wx/ui/version_select.py
+++ b/amulet_map_editor/api/wx/ui/version_select.py
@@ -40,8 +40,13 @@ class PlatformSelect(wx.Panel):
         **kwargs
     ):
         super().__init__(parent, style=wx.BORDER_SIMPLE)
-        self._sizer = wx.BoxSizer(wx.VERTICAL)
-        self.SetSizer(self._sizer)
+        self._sizer = wx.FlexGridSizer(2, 5, 5)
+        self._sizer.AddGrowableCol(0, proportion=0)
+        self._sizer.AddGrowableCol(1, proportion=1)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self._sizer, 1, wx.EXPAND | wx.ALL, 5)
+        self.SetSizer(sizer)
 
         self._translation_manager = translation_manager
         self._allow_universal = allow_universal
@@ -62,12 +67,10 @@ class PlatformSelect(wx.Panel):
     def _add_ui_element(
         self, label: str, obj: Type[wx.Control], shown=True, **kwargs
     ) -> Any:
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self._sizer.Add(sizer, 0, wx.EXPAND | wx.ALL, 5)
         text = wx.StaticText(self, label=label, style=wx.ALIGN_CENTER)
-        sizer.Add(text, 1, wx.CENTRE)
+        self._sizer.Add(text, 0, wx.ALIGN_CENTRE)
         wx_obj = obj(self, **kwargs)
-        sizer.Add(wx_obj, 2, wx.CENTER)
+        self._sizer.Add(wx_obj, 1, wx.EXPAND)
         if not shown:
             text.Hide()
             wx_obj.Hide()

--- a/amulet_map_editor/api/wx/ui/widget_size_changed.py
+++ b/amulet_map_editor/api/wx/ui/widget_size_changed.py
@@ -1,0 +1,8 @@
+from wx.lib import newevent
+
+(
+    WidgetSizeChangeEvent,
+    EVT_WIDGET_SIZE_CHANGED,
+) = (
+    newevent.NewCommandEvent()
+)  # Emitted when a widget's size changed in a way that the parent needs to be aware of.

--- a/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
@@ -218,6 +218,8 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
         evt.Skip()
 
     def _resize(self):
+        widget = self.canvas.GetParent()
+        widget.Freeze()
         settings_panel_size = self._settings_panel.GetBestSize()
         self._settings_panel.SetSize(
             wx.Rect(
@@ -237,3 +239,4 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
             wx.Rect(0, 30 + settings_panel_size.GetHeight(), panel_width, panel_height)
         )
         self._operation_panel.Raise()
+        widget.Thaw()

--- a/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
+++ b/amulet_map_editor/programs/edit/api/ui/tool/base_operation_choice.py
@@ -10,6 +10,7 @@ import subprocess
 from amulet_map_editor.api import image
 from amulet_map_editor.api.wx.ui.simple import SimpleChoiceAny
 from amulet_map_editor.api.wx.ui.traceback_dialog import TracebackDialog
+from amulet_map_editor.api.wx.ui.widget_size_changed import EVT_WIDGET_SIZE_CHANGED
 
 from amulet_map_editor.programs.edit.api.operations import OperationUIType
 from amulet_map_editor.programs.edit.api.operations.manager import UIOperationManager
@@ -49,6 +50,7 @@ class BaseOperationChoiceToolUI(wx.BoxSizer, BaseToolUI):
         self._operation_panel.Hide()
         self._operation_sizer = wx.BoxSizer(wx.VERTICAL)
         self._operation_panel.SetSizer(self._operation_sizer)
+        self._operation_panel.Bind(EVT_WIDGET_SIZE_CHANGED, self._on_resize)
 
         assert isinstance(
             self.OperationGroupName, str

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
@@ -24,10 +24,6 @@ SOFTWARE.
 from typing import TYPE_CHECKING, Tuple
 import wx
 
-from amulet.api.selection import SelectionGroup
-from amulet.api.block import Block
-from amulet.api.data_types import Dimension, OperationReturnType
-
 from amulet_map_editor.api.wx.ui.base_select import EVT_PICK
 from amulet_map_editor.api.wx.ui.block_select import BlockDefine
 from amulet_map_editor.programs.edit.api.operations import DefaultOperationUI

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
@@ -47,7 +47,6 @@ class Fill(wx.Panel, DefaultOperationUI):
     ):
         wx.Panel.__init__(self, parent)
         DefaultOperationUI.__init__(self, parent, canvas, world, options_path)
-        self.Freeze()
         self._sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(self._sizer)
 
@@ -68,9 +67,6 @@ class Fill(wx.Panel, DefaultOperationUI):
         self._sizer.Add(
             self._run_button, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5
         )
-
-        self.Layout()
-        self.Thaw()
 
     @property
     def wx_add_options(self) -> Tuple[int, ...]:

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/fill.py
@@ -26,6 +26,7 @@ import wx
 
 from amulet_map_editor.api.wx.ui.base_select import EVT_PICK
 from amulet_map_editor.api.wx.ui.block_select import BlockDefine
+from amulet_map_editor.api.wx.ui.simple import SimpleScrollablePanel
 from amulet_map_editor.programs.edit.api.operations import DefaultOperationUI
 
 if TYPE_CHECKING:
@@ -46,17 +47,20 @@ class Fill(wx.Panel, DefaultOperationUI):
         self._sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(self._sizer)
 
+        self._scroll = SimpleScrollablePanel(self)
+        self._sizer.Add(self._scroll, 1, wx.EXPAND)
+
         options = self._load_options({})
 
         self._block_define = BlockDefine(
-            self,
+            self._scroll,
             world.translation_manager,
             wx.VERTICAL,
             *(options.get("fill_block_options", []) or [world.level_wrapper.platform]),
             show_pick_block=True
         )
         self._block_define.Bind(EVT_PICK, self._on_pick_block_button)
-        self._sizer.Add(self._block_define, 1, wx.ALL | wx.EXPAND, 5)
+        self._scroll.sizer.Add(self._block_define, 1, wx.ALL | wx.EXPAND, 5)
 
         self._run_button = wx.Button(self, label="Run Operation")
         self._run_button.Bind(wx.EVT_BUTTON, self._run_operation)

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -61,7 +61,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
             wildcard_properties=True,
             show_pick_block=True
         )
-        self._sizer.Add(self._original_block, 1, wx.ALL | wx.EXPAND, 5)
+        self._sizer.Add(self._original_block, 0, wx.ALL | wx.EXPAND, 5)
         self._original_block.Bind(EVT_PICK, lambda evt: self._on_pick_block_button(1))
         self._replacement_block = BlockDefine(
             self,
@@ -73,7 +73,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
             ),
             show_pick_block=True
         )
-        self._sizer.Add(self._replacement_block, 1, wx.ALL | wx.EXPAND, 5)
+        self._sizer.Add(self._replacement_block, 0, wx.ALL | wx.EXPAND, 5)
         self._replacement_block.Bind(
             EVT_PICK, lambda evt: self._on_pick_block_button(2)
         )

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -229,7 +229,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
             sx, sy = self.GetSizer().CalcMin()
             return (
                 sx + wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X),
-                sy + wx.SystemSettings.GetMetric(wx.SYS_HSCROLL_Y),
+                sy,
             )
 
 

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -78,16 +78,16 @@ class Replace(wx.Panel, DefaultOperationUI):
             ),
             show_pick_block=True
         )
-        self._scroll.sizer.Add(self._replacement_block, 0, wx.LEFT | wx.TOP | wx.RIGHT | wx.EXPAND, 5)
+        self._scroll.sizer.Add(
+            self._replacement_block, 0, wx.LEFT | wx.TOP | wx.RIGHT | wx.EXPAND, 5
+        )
         self._replacement_block.Bind(
             EVT_PICK, lambda evt: self._on_pick_block_button(2)
         )
 
         self._run_button = wx.Button(self, label="Run Operation")
         self._run_button.Bind(wx.EVT_BUTTON, self._run_operation)
-        self._sizer.Add(
-            self._run_button, 0, wx.ALL | wx.EXPAND, 5
-        )
+        self._sizer.Add(self._run_button, 0, wx.ALL | wx.EXPAND, 5)
 
     @property
     def wx_add_options(self) -> Tuple[int, ...]:

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from amulet_map_editor.programs.edit.api.canvas import EditCanvas
 
 
-class Replace(SimpleScrollablePanel, DefaultOperationUI):
+class Replace(wx.Panel, DefaultOperationUI):
     def __init__(
         self,
         parent: wx.Window,
@@ -45,12 +45,18 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
         world: "BaseLevel",
         options_path: str,
     ):
-        SimpleScrollablePanel.__init__(self, parent)
+        wx.Panel.__init__(self, parent)
         DefaultOperationUI.__init__(self, parent, canvas, world, options_path)
         options = self._load_options({})
 
+        self._sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(self._sizer)
+
+        self._scroll = SimpleScrollablePanel(self)
+        self._sizer.Add(self._scroll, 1, wx.EXPAND)
+
         self._original_block = BlockDefine(
-            self,
+            self._scroll,
             world.level_wrapper.translation_manager,
             wx.VERTICAL,
             *(
@@ -60,10 +66,10 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
             wildcard_properties=True,
             show_pick_block=True
         )
-        self._sizer.Add(self._original_block, 0, wx.ALL | wx.EXPAND, 5)
+        self._scroll.sizer.Add(self._original_block, 0, wx.ALL | wx.EXPAND, 5)
         self._original_block.Bind(EVT_PICK, lambda evt: self._on_pick_block_button(1))
         self._replacement_block = BlockDefine(
-            self,
+            self._scroll,
             world.level_wrapper.translation_manager,
             wx.VERTICAL,
             *(
@@ -72,7 +78,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
             ),
             show_pick_block=True
         )
-        self._sizer.Add(self._replacement_block, 0, wx.ALL | wx.EXPAND, 5)
+        self._scroll.sizer.Add(self._replacement_block, 0, wx.LEFT | wx.TOP | wx.RIGHT | wx.EXPAND, 5)
         self._replacement_block.Bind(
             EVT_PICK, lambda evt: self._on_pick_block_button(2)
         )
@@ -80,7 +86,7 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
         self._run_button = wx.Button(self, label="Run Operation")
         self._run_button.Bind(wx.EVT_BUTTON, self._run_operation)
         self._sizer.Add(
-            self._run_button, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5
+            self._run_button, 0, wx.ALL | wx.EXPAND, 5
         )
 
     @property
@@ -216,17 +222,6 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
 
             count += 1
             yield count / iter_count
-
-    def DoGetBestClientSize(self):
-        sizer = self.GetSizer()
-        if sizer is None:
-            return -1, -1
-        else:
-            sx, sy = self.GetSizer().CalcMin()
-            return (
-                sx + wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X),
-                sy,
-            )
 
 
 export = {

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/replace.py
@@ -47,7 +47,6 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
     ):
         SimpleScrollablePanel.__init__(self, parent)
         DefaultOperationUI.__init__(self, parent, canvas, world, options_path)
-        self.Freeze()
         options = self._load_options({})
 
         self._original_block = BlockDefine(
@@ -83,9 +82,6 @@ class Replace(SimpleScrollablePanel, DefaultOperationUI):
         self._sizer.Add(
             self._run_button, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5
         )
-
-        self.Layout()
-        self.Thaw()
 
     @property
     def wx_add_options(self) -> Tuple[int, ...]:

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
@@ -30,6 +30,7 @@ import wx
 from amulet_map_editor.api.wx.ui.base_select import EVT_PICK
 from amulet_map_editor.api.wx.ui.simple import SimpleDialog
 from amulet_map_editor.api.wx.ui.block_select import BlockDefine
+from amulet_map_editor.api.wx.ui.simple import SimpleScrollablePanel
 from amulet_map_editor.programs.edit.api.operations import DefaultOperationUI
 from amulet_map_editor.api import image
 
@@ -109,20 +110,23 @@ class Waterlog(wx.Panel, DefaultOperationUI):
         )
         self._mode_description.Fit()
 
+        self._scroll = SimpleScrollablePanel(self)
+        self._sizer.Add(self._scroll, 1, wx.EXPAND | wx.TOP, 5)
+
         self._block_define = BlockDefine(
-            self,
+            self._scroll,
             world.level_wrapper.translation_manager,
             wx.VERTICAL,
             *(options.get("fill_block_options", []) or [world.level_wrapper.platform]),
             show_pick_block=True,
         )
         self._block_define.Bind(EVT_PICK, self._on_pick_block_button)
-        self._sizer.Add(self._block_define, 1, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 5)
+        self._scroll.sizer.Add(self._block_define, 1, wx.LEFT | wx.RIGHT | wx.EXPAND, 5)
 
         self._run_button = wx.Button(self, label="Run Operation")
         self._run_button.Bind(wx.EVT_BUTTON, self._run_operation)
         self._sizer.Add(
-            self._run_button, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5
+            self._run_button, 0, wx.ALL | wx.EXPAND, 5
         )
 
         self.Layout()

--- a/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
+++ b/amulet_map_editor/programs/edit/plugins/operations/stock_plugins/operations/waterlog.py
@@ -125,9 +125,7 @@ class Waterlog(wx.Panel, DefaultOperationUI):
 
         self._run_button = wx.Button(self, label="Run Operation")
         self._run_button.Bind(wx.EVT_BUTTON, self._run_operation)
-        self._sizer.Add(
-            self._run_button, 0, wx.ALL | wx.EXPAND, 5
-        )
+        self._sizer.Add(self._run_button, 0, wx.ALL | wx.EXPAND, 5)
 
         self.Layout()
         self.Thaw()


### PR DESCRIPTION
The fill, replace and waterlog tools had some layout issues that caused them to be unusable.
This adds an event for when a widget needs to change size in a way that the parent needs to handle.
Add scroll areas to fill and waterlog in case they need to be larger than the screen.
Minor improvements to the fill, replace and waterlog tools.